### PR TITLE
Fix dataset existence check

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
@@ -242,7 +242,7 @@ public class N5FSReader implements N5Reader {
 	@Override
 	public boolean datasetExists(final String pathName) throws IOException {
 
-		return exists(pathName) && getDatasetAttributes(pathName) != null;
+		return exists(pathName) && hasAttributes(pathName) && getDatasetAttributes(pathName) != null;
 	}
 
 	@Override

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
@@ -136,7 +136,7 @@ public class N5FSReader implements N5Reader {
 	}
 
 	/**
-	 * Reads or creates the attributes map of a group or dataset.
+	 * Reads the attributes map of a group or dataset.
 	 *
 	 * @param pathName group path
 	 * @return

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
@@ -245,6 +245,13 @@ public class N5FSReader implements N5Reader {
 		return exists(pathName) && getDatasetAttributes(pathName) != null;
 	}
 
+	@Override
+	public boolean hasAttributes(final String pathName) {
+
+		final Path path = Paths.get(basePath, pathName, jsonFile);
+		return Files.exists(path) && Files.isRegularFile(path);
+	}
+
 	/**
 	 * Creates the path for a data block in a dataset at a given grid position.
 	 *

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
@@ -136,7 +136,7 @@ public class N5FSReader implements N5Reader {
 	}
 
 	/**
-	 * Reads the attributes map of a group or dataset.
+	 * Reads or creates the attributes map of a group or dataset.
 	 *
 	 * @param pathName group path
 	 * @return

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
@@ -149,6 +149,9 @@ public class N5FSReader implements N5Reader {
 	public HashMap<String, JsonElement> getAttributes(final String pathName) throws IOException {
 
 		final Path path = Paths.get(basePath, pathName, jsonFile);
+		if (exists(pathName) && !Files.exists(path))
+			return new HashMap<>();
+
 		final LockedFileChannel lockedFileChannel = new LockedFileChannel(path);
 		final Type mapType = new TypeToken<HashMap<String, JsonElement>>(){}.getType();
 		HashMap<String, JsonElement> map = gson.fromJson(Channels.newReader(lockedFileChannel.channel, "UTF-8"), mapType);
@@ -242,14 +245,7 @@ public class N5FSReader implements N5Reader {
 	@Override
 	public boolean datasetExists(final String pathName) throws IOException {
 
-		return exists(pathName) && hasAttributes(pathName) && getDatasetAttributes(pathName) != null;
-	}
-
-	@Override
-	public boolean hasAttributes(final String pathName) {
-
-		final Path path = Paths.get(basePath, pathName, jsonFile);
-		return Files.exists(path) && Files.isRegularFile(path);
+		return exists(pathName) && getDatasetAttributes(pathName) != null;
 	}
 
 	/**

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
@@ -105,14 +105,6 @@ public interface N5Reader {
 	public boolean datasetExists(final String pathName) throws IOException;
 
 	/**
-	 * Test whether a group or dataset has attributes.
-	 *
-	 * @param pathName group path
-	 * @return
-	 */
-	public boolean hasAttributes(final String pathName);
-
-	/**
 	 * List all groups (including datasets) in a group.
 	 *
 	 * @param pathName group path

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
@@ -105,6 +105,14 @@ public interface N5Reader {
 	public boolean datasetExists(final String pathName) throws IOException;
 
 	/**
+	 * Test whether a group or dataset has attributes.
+	 *
+	 * @param pathName group path
+	 * @return
+	 */
+	public boolean hasAttributes(final String pathName);
+
+	/**
 	 * List all groups (including datasets) in a group.
 	 *
 	 * @param pathName group path

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
@@ -41,7 +41,7 @@ import com.google.gson.JsonElement;
 public interface N5Reader {
 
 	/**
-	 * Reads or creates the attributes map of a group or dataset.
+	 * Reads the attributes map of a group or dataset.
 	 *
 	 * @param pathName group path
 	 * @return

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
@@ -41,7 +41,7 @@ import com.google.gson.JsonElement;
 public interface N5Reader {
 
 	/**
-	 * Reads the attributes map of a group or dataset.
+	 * Reads or creates the attributes map of a group or dataset.
 	 *
 	 * @param pathName group path
 	 * @return

--- a/src/test/java/org/janelia/saalfeldlab/n5/N5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/N5Test.java
@@ -351,15 +351,14 @@ public class N5Test {
 			n5.createDataset(datasetName2, dimensions, blockSize, DataType.UINT64, CompressionType.RAW);
 			Assert.assertTrue(n5.exists(datasetName2));
 			Assert.assertTrue(n5.datasetExists(datasetName2));
-			Assert.assertTrue(n5.hasAttributes(datasetName2));
 
 			n5.createGroup(groupName2);
 			Assert.assertTrue(n5.exists(groupName2));
 			Assert.assertFalse(n5.datasetExists(groupName2));
-			Assert.assertFalse(n5.hasAttributes(groupName2));
+			Assert.assertTrue(n5.getAttributes(groupName2).isEmpty());
 
 			n5.setAttribute(groupName2, "test", "test");
-			Assert.assertTrue(n5.hasAttributes(groupName2));
+			Assert.assertFalse(n5.getAttributes(groupName2).isEmpty());
 		} catch (final IOException e) {
 			fail(e.getMessage());
 		}

--- a/src/test/java/org/janelia/saalfeldlab/n5/N5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/N5Test.java
@@ -341,4 +341,27 @@ public class N5Test {
 			fail(e.getMessage());
 		}
 	}
+
+	@Test
+	public void testExists() {
+
+		final String groupName2 = groupName + "-2";
+		final String datasetName2 = datasetName + "-2";
+		try {
+			n5.createDataset(datasetName2, dimensions, blockSize, DataType.UINT64, CompressionType.RAW);
+			Assert.assertTrue(n5.exists(datasetName2));
+			Assert.assertTrue(n5.datasetExists(datasetName2));
+			Assert.assertTrue(n5.hasAttributes(datasetName2));
+
+			n5.createGroup(groupName2);
+			Assert.assertTrue(n5.exists(groupName2));
+			Assert.assertFalse(n5.datasetExists(groupName2));
+			Assert.assertFalse(n5.hasAttributes(groupName2));
+
+			n5.setAttribute(groupName2, "test", "test");
+			Assert.assertTrue(n5.hasAttributes(groupName2));
+		} catch (final IOException e) {
+			fail(e.getMessage());
+		}
+	}
 }


### PR DESCRIPTION
https://github.com/saalfeldlab/n5/blob/1.1.1/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java#L245
The above code behaves incorrectly in the case there is a group with the same name but with no attributes. It throws an `IOException` (tries to load missing file _attributes.json_). But I would expect it to return `false` as in the case when the attributes are not consistent with the mandatory dataset attributes.

This PR introduces `hasAttributes()` method which tests whether a file _attributes.json_ exists. This method also allows to safely test for its existence before reading the attributes of a group (where this file is not guaranteed to be present).