### PR TITLE
Fix files stream leak in list()

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
@@ -40,6 +40,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.stream.Stream;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -277,9 +278,12 @@ public class N5FSReader implements N5Reader {
 	public String[] list(final String pathName) throws IOException {
 
 		final Path path = Paths.get(basePath, pathName);
-		return Files.list(path)
-				.filter(a -> Files.isDirectory(a))
-				.map(a -> path.relativize(a).toString())
-				.toArray(n -> new String[n]);
+		try (final Stream<Path> pathStream = Files.list(path))
+		{
+			return pathStream
+					.filter(a -> Files.isDirectory(a))
+					.map(a -> path.relativize(a).toString())
+					.toArray(n -> new String[n]);
+		}
 	}
 }


### PR DESCRIPTION
The file stream in `N5FSReader.list()` was never closed which was causing a leak.
I implemented parallel remove operation for N5 containers, and at some point it threw `java.nio.file.FileSystemException: Too many open files`. Closing the stream fixes the issue.