### PR TITLE
Add flexibility to N5FS for numElements

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/ByteArrayDataBlock.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/ByteArrayDataBlock.java
@@ -46,4 +46,10 @@ public class ByteArrayDataBlock extends AbstractDataBlock<byte[]> {
 		if (buffer.array() != getData())
 			buffer.get(getData());
 	}
+	
+	@Override
+	public int getNumElements() {
+		
+		return data.length;
+	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/DataBlock.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/DataBlock.java
@@ -94,6 +94,15 @@ public interface DataBlock<T> {
 	public void readData(final ByteBuffer buffer);
 
 	/**
+	 * Returns the number of elements in this {@link DataBlock}. This number is
+	 * not necessarily equal {@link #getNumElements(int[])
+	 * getNumElements(getSize())}.
+	 * 
+	 * @return
+	 */
+	public int getNumElements();
+
+	/**
 	 * Returns the number of elements in a box of given size.
 	 *
 	 * @param size

--- a/src/main/java/org/janelia/saalfeldlab/n5/DataType.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/DataType.java
@@ -25,8 +25,6 @@
  */
 package org.janelia.saalfeldlab.n5;
 
-import static org.janelia.saalfeldlab.n5.DataBlock.getNumElements;
-
 import java.lang.reflect.Type;
 
 import com.google.gson.JsonDeserializationContext;
@@ -44,17 +42,17 @@ import com.google.gson.JsonSerializer;
  */
 public enum DataType {
 
-	UINT8("uint8", (blockSize, gridPosition) -> new ByteArrayDataBlock(blockSize, gridPosition, new byte[getNumElements(blockSize)])),
-	UINT16("uint16", (blockSize, gridPosition) -> new ShortArrayDataBlock(blockSize, gridPosition, new short[getNumElements(blockSize)])),
-	UINT32("uint32", (blockSize, gridPosition) -> new IntArrayDataBlock(blockSize, gridPosition, new int[getNumElements(blockSize)])),
-	UINT64("uint64", (blockSize, gridPosition) -> new LongArrayDataBlock(blockSize, gridPosition, new long[getNumElements(blockSize)])),
-	INT8("int8", (blockSize, gridPosition) -> new ByteArrayDataBlock(blockSize, gridPosition, new byte[getNumElements(blockSize)])),
-	INT16("int16", (blockSize, gridPosition) -> new ShortArrayDataBlock(blockSize, gridPosition, new short[getNumElements(blockSize)])),
-	INT32("int32", (blockSize, gridPosition) -> new IntArrayDataBlock(blockSize, gridPosition, new int[getNumElements(blockSize)])),
-	INT64("int64", (blockSize, gridPosition) -> new LongArrayDataBlock(blockSize, gridPosition, new long[getNumElements(blockSize)])),
-	FLOAT32("float32", (blockSize, gridPosition) -> new FloatArrayDataBlock(blockSize, gridPosition, new float[getNumElements(blockSize)])),
-	FLOAT64("float64", (blockSize, gridPosition) -> new DoubleArrayDataBlock(blockSize, gridPosition, new double[getNumElements(blockSize)]));
-
+	UINT8("uint8", (blockSize, gridPosition, numElements) -> new ByteArrayDataBlock(blockSize, gridPosition, new byte[numElements])),
+	UINT16("uint16", (blockSize, gridPosition, numElements) -> new ShortArrayDataBlock(blockSize, gridPosition, new short[numElements])),
+	UINT32("uint32", (blockSize, gridPosition, numElements) -> new IntArrayDataBlock(blockSize, gridPosition, new int[numElements])),
+	UINT64("uint64", (blockSize, gridPosition, numElements) -> new LongArrayDataBlock(blockSize, gridPosition, new long[numElements])),
+	INT8("int8", (blockSize, gridPosition, numElements) -> new ByteArrayDataBlock(blockSize, gridPosition, new byte[numElements])),
+	INT16("int16", (blockSize, gridPosition, numElements) -> new ShortArrayDataBlock(blockSize, gridPosition, new short[numElements])),
+	INT32("int32", (blockSize, gridPosition, numElements) -> new IntArrayDataBlock(blockSize, gridPosition, new int[numElements])),
+	INT64("int64", (blockSize, gridPosition, numElements) -> new LongArrayDataBlock(blockSize, gridPosition, new long[numElements])),
+	FLOAT32("float32", (blockSize, gridPosition, numElements) -> new FloatArrayDataBlock(blockSize, gridPosition, new float[numElements])),
+	FLOAT64("float64", (blockSize, gridPosition, numElements) -> new DoubleArrayDataBlock(blockSize, gridPosition, new double[numElements]));
+	
 	private final String label;
 
 	private DataBlockFactory dataBlockFactory;
@@ -79,14 +77,14 @@ public enum DataType {
 		return null;
 	}
 
-	public DataBlock<?> createDataBlock(final int[] blockSize, final long[] gridPosition) {
+	public DataBlock<?> createDataBlock(final int[] blockSize, final long[] gridPosition, final int numElements) {
 
-		return dataBlockFactory.createDataBlock(blockSize, gridPosition);
+		return dataBlockFactory.createDataBlock(blockSize, gridPosition, numElements);
 	}
 
 	private static interface DataBlockFactory {
 
-		public DataBlock<?> createDataBlock(final int[] blockSize, final long[] gridPosition);
+		public DataBlock<?> createDataBlock(final int[] blockSize, final long[] gridPosition, final int numElements);
 	}
 
 	static public class JsonAdapter implements JsonDeserializer<DataType>, JsonSerializer<DataType> {

--- a/src/main/java/org/janelia/saalfeldlab/n5/DoubleArrayDataBlock.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/DoubleArrayDataBlock.java
@@ -47,4 +47,10 @@ public class DoubleArrayDataBlock extends AbstractDataBlock<double[]> {
 
 		buffer.asDoubleBuffer().get(data);
 	}
+	
+	@Override
+	public int getNumElements() {
+		
+		return data.length;
+	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/FloatArrayDataBlock.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/FloatArrayDataBlock.java
@@ -46,4 +46,10 @@ public class FloatArrayDataBlock extends AbstractDataBlock<float[]> {
 
 		buffer.asFloatBuffer().get(data);
 	}
+	
+	@Override
+	public int getNumElements() {
+		
+		return data.length;
+	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/IntArrayDataBlock.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/IntArrayDataBlock.java
@@ -47,4 +47,10 @@ public class IntArrayDataBlock extends AbstractDataBlock<int[]> {
 
 		buffer.asIntBuffer().get(data);
 	}
+	
+	@Override
+	public int getNumElements() {
+		
+		return data.length;
+	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/LongArrayDataBlock.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/LongArrayDataBlock.java
@@ -47,4 +47,10 @@ public class LongArrayDataBlock extends AbstractDataBlock<long[]> {
 
 		buffer.asLongBuffer().get(data);
 	}
+	
+	@Override
+	public int getNumElements() {
+		
+		return data.length;
+	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
@@ -223,11 +223,20 @@ public class N5FSReader implements N5Reader {
 
 		try (final InputStream in = Channels.newInputStream(lockedChannel.channel)) {
 			final DataInputStream dis = new DataInputStream(in);
-			final int nDim = dis.readInt();
+			final short mode = dis.readShort();
+			final int nDim = dis.readShort();
 			final int[] blockSize = new int[nDim];
 			for (int d = 0; d < nDim; ++d)
 				blockSize[d] = dis.readInt();
-			final DataBlock<?> dataBlock = datasetAttributes.getDataType().createDataBlock(blockSize, gridPosition);
+			final int numElements;
+			switch (mode) {
+			case 1:
+				numElements = dis.readInt();
+				break;
+			default:
+				numElements = DataBlock.getNumElements(blockSize);
+			}
+			final DataBlock<?> dataBlock = datasetAttributes.getDataType().createDataBlock(blockSize, gridPosition, numElements);
 
 			final BlockReader reader = datasetAttributes.getCompressionType().getReader();
 			reader.read(dataBlock, lockedChannel.channel);

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
@@ -238,7 +238,13 @@ public class N5FSWriter extends N5FSReader implements N5Writer {
 			final FileChannel channel = out.getChannel();
 			final FileLock lock = channel.lock();
 			final DataOutputStream dos = new DataOutputStream(out);
-			dos.writeInt(datasetAttributes.getNumDimensions());
+			
+			if (dataBlock.getNumElements() == DataBlock.getNumElements(dataBlock.getSize()))
+				dos.writeShort(0);
+			else
+				dos.writeShort(1);
+			
+			dos.writeShort(datasetAttributes.getNumDimensions());
 			for (final int size : dataBlock.getSize())
 				dos.writeInt(size);
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/ShortArrayDataBlock.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/ShortArrayDataBlock.java
@@ -47,4 +47,10 @@ public class ShortArrayDataBlock extends AbstractDataBlock<short[]> {
 
 		buffer.asShortBuffer().get(data);
 	}
+	
+	@Override
+	public int getNumElements() {
+		
+		return data.length;
+	}
 }


### PR DESCRIPTION
changed first two bytes of N5FS file format to represent a mode, where 0
indicates the old 'mode' (for backwards compatibility), and 1 indicates
that there is another integer stored after the dimensions representing
the number of elements, necessary for future flexibility