### PR TITLE
Add serializable data type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,11 @@
 			<version>1.14</version>
 		</dependency>
 		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.5</version>
+		</dependency>
+		<dependency>
 			<groupId>net.jpountz.lz4</groupId>
 			<artifactId>lz4</artifactId>
 			<version>1.3.0</version>

--- a/src/main/java/org/janelia/saalfeldlab/n5/AbstractDataBlock.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/AbstractDataBlock.java
@@ -36,7 +36,7 @@ public abstract class AbstractDataBlock<T> implements DataBlock<T> {
 
 	protected final int[] size;
 	protected final long[] gridPosition;
-	protected final T data;
+	protected T data;
 
 	public AbstractDataBlock(final int[] size, final long[] gridPosition, final T data) {
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/Bzip2BlockReaderWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/Bzip2BlockReaderWriter.java
@@ -33,6 +33,7 @@ import java.nio.channels.FileChannel;
 
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
+import org.apache.commons.io.IOUtils;
 
 public class Bzip2BlockReaderWriter implements BlockReader, BlockWriter {
 
@@ -41,9 +42,10 @@ public class Bzip2BlockReaderWriter implements BlockReader, BlockWriter {
 			final B dataBlock,
 			final ByteChannel channel) throws IOException {
 
-		final ByteBuffer buffer = dataBlock.toByteBuffer();
+		final ByteBuffer buffer;
 		try (final BZip2CompressorInputStream in = new BZip2CompressorInputStream(Channels.newInputStream(channel))) {
-			in.read(buffer.array());
+			final byte[] bytes = IOUtils.toByteArray(in);
+			buffer = ByteBuffer.wrap(bytes);
 		}
 		dataBlock.readData(buffer);
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/Bzip2BlockReaderWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/Bzip2BlockReaderWriter.java
@@ -26,40 +26,23 @@
 package org.janelia.saalfeldlab.n5;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.ByteChannel;
-import java.nio.channels.Channels;
-import java.nio.channels.FileChannel;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
-import org.apache.commons.io.IOUtils;
 
-public class Bzip2BlockReaderWriter implements BlockReader, BlockWriter {
+public class Bzip2BlockReaderWriter extends AbstractBlockReaderWriter {
 
 	@Override
-	public <T, B extends DataBlock<T>> void read(
-			final B dataBlock,
-			final ByteChannel channel) throws IOException {
+	protected InputStream getInputStream(final InputStream in) throws IOException {
 
-		final ByteBuffer buffer;
-		try (final BZip2CompressorInputStream in = new BZip2CompressorInputStream(Channels.newInputStream(channel))) {
-			final byte[] bytes = IOUtils.toByteArray(in);
-			buffer = ByteBuffer.wrap(bytes);
-		}
-		dataBlock.readData(buffer);
+		return new BZip2CompressorInputStream(in);
 	}
 
 	@Override
-	public <T> void write(
-			final DataBlock<T> dataBlock,
-			final FileChannel channel) throws IOException {
+	protected OutputStream getOutputStream(final OutputStream out) throws IOException {
 
-		final ByteBuffer buffer = dataBlock.toByteBuffer();
-		try (final BZip2CompressorOutputStream out = new BZip2CompressorOutputStream(Channels.newOutputStream(channel))) {
-			out.write(buffer.array());
-			out.finish();
-		}
-		channel.truncate(channel.position());
+		return new BZip2CompressorOutputStream(out);
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/DataType.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/DataType.java
@@ -26,6 +26,7 @@
 package org.janelia.saalfeldlab.n5;
 
 import java.lang.reflect.Type;
+import java.io.Serializable;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
@@ -51,7 +52,10 @@ public enum DataType {
 	INT32("int32", (blockSize, gridPosition, numElements) -> new IntArrayDataBlock(blockSize, gridPosition, new int[numElements])),
 	INT64("int64", (blockSize, gridPosition, numElements) -> new LongArrayDataBlock(blockSize, gridPosition, new long[numElements])),
 	FLOAT32("float32", (blockSize, gridPosition, numElements) -> new FloatArrayDataBlock(blockSize, gridPosition, new float[numElements])),
-	FLOAT64("float64", (blockSize, gridPosition, numElements) -> new DoubleArrayDataBlock(blockSize, gridPosition, new double[numElements]));
+	FLOAT64("float64", (blockSize, gridPosition, numElements) -> new DoubleArrayDataBlock(blockSize, gridPosition, new double[numElements])),
+	
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	SERIALIZABLE("serializable", (blockSize, gridPosition, numElements) -> new SerializableArrayDataBlock(blockSize, gridPosition, new Serializable[numElements]));
 	
 	private final String label;
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/GzipBlockReaderWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/GzipBlockReaderWriter.java
@@ -26,40 +26,23 @@
 package org.janelia.saalfeldlab.n5;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.ByteChannel;
-import java.nio.channels.Channels;
-import java.nio.channels.FileChannel;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
-import org.apache.commons.io.IOUtils;
 
-public class GzipBlockReaderWriter implements BlockReader, BlockWriter {
+public class GzipBlockReaderWriter extends AbstractBlockReaderWriter {
 
 	@Override
-	public <T, B extends DataBlock<T>> void read(
-			final B dataBlock,
-			final ByteChannel channel) throws IOException {
+	protected InputStream getInputStream(final InputStream in) throws IOException {
 
-		final ByteBuffer buffer;
-		try (final GzipCompressorInputStream in = new GzipCompressorInputStream(Channels.newInputStream(channel))) {
-			final byte[] bytes = IOUtils.toByteArray(in);
-			buffer = ByteBuffer.wrap(bytes);
-		}
-		dataBlock.readData(buffer);
+		return new GzipCompressorInputStream(in);
 	}
 
 	@Override
-	public <T> void write(
-			final DataBlock<T> dataBlock,
-			final FileChannel channel) throws IOException {
+	protected OutputStream getOutputStream(final OutputStream out) throws IOException {
 
-		final ByteBuffer buffer = dataBlock.toByteBuffer();
-		try (final GzipCompressorOutputStream os = new GzipCompressorOutputStream(Channels.newOutputStream(channel))) {
-			os.write(buffer.array());
-			os.flush();
-			channel.truncate(channel.position());
-		}
+		return new GzipCompressorOutputStream(out);
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/GzipBlockReaderWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/GzipBlockReaderWriter.java
@@ -33,6 +33,7 @@ import java.nio.channels.FileChannel;
 
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.apache.commons.io.IOUtils;
 
 public class GzipBlockReaderWriter implements BlockReader, BlockWriter {
 
@@ -41,9 +42,10 @@ public class GzipBlockReaderWriter implements BlockReader, BlockWriter {
 			final B dataBlock,
 			final ByteChannel channel) throws IOException {
 
-		final ByteBuffer buffer = dataBlock.toByteBuffer();
+		final ByteBuffer buffer;
 		try (final GzipCompressorInputStream in = new GzipCompressorInputStream(Channels.newInputStream(channel))) {
-			in.read(buffer.array());
+			final byte[] bytes = IOUtils.toByteArray(in);
+			buffer = ByteBuffer.wrap(bytes);
 		}
 		dataBlock.readData(buffer);
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/Lz4BlockReaderWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/Lz4BlockReaderWriter.java
@@ -26,40 +26,23 @@
 package org.janelia.saalfeldlab.n5;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.ByteChannel;
-import java.nio.channels.Channels;
-import java.nio.channels.FileChannel;
-
-import org.apache.commons.io.IOUtils;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 import net.jpountz.lz4.LZ4BlockInputStream;
 import net.jpountz.lz4.LZ4BlockOutputStream;
 
-public class Lz4BlockReaderWriter implements BlockReader, BlockWriter {
+public class Lz4BlockReaderWriter extends AbstractBlockReaderWriter {
 
 	@Override
-	public <T, B extends DataBlock<T>> void read(
-			final B dataBlock,
-			final ByteChannel channel) throws IOException {
+	protected InputStream getInputStream(final InputStream in) throws IOException {
 
-		final ByteBuffer buffer;
-		try (final LZ4BlockInputStream in = new LZ4BlockInputStream(Channels.newInputStream(channel))) {
-			final byte[] bytes = IOUtils.toByteArray(in);
-			buffer = ByteBuffer.wrap(bytes);
-		}
-		dataBlock.readData(buffer);
+		return new LZ4BlockInputStream(in);
 	}
 
 	@Override
-	public <T> void write(
-			final DataBlock<T> dataBlock,
-			final FileChannel channel) throws IOException {
+	protected OutputStream getOutputStream(final OutputStream out) throws IOException {
 
-		final ByteBuffer buffer = dataBlock.toByteBuffer();
-		try (final LZ4BlockOutputStream out = new LZ4BlockOutputStream(Channels.newOutputStream(channel))) {
-			out.write(buffer.array());
-			out.finish();
-		}
+		return new LZ4BlockOutputStream(out);
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/Lz4BlockReaderWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/Lz4BlockReaderWriter.java
@@ -31,6 +31,8 @@ import java.nio.channels.ByteChannel;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 
+import org.apache.commons.io.IOUtils;
+
 import net.jpountz.lz4.LZ4BlockInputStream;
 import net.jpountz.lz4.LZ4BlockOutputStream;
 
@@ -41,9 +43,10 @@ public class Lz4BlockReaderWriter implements BlockReader, BlockWriter {
 			final B dataBlock,
 			final ByteChannel channel) throws IOException {
 
-		final ByteBuffer buffer = dataBlock.toByteBuffer();
+		final ByteBuffer buffer;
 		try (final LZ4BlockInputStream in = new LZ4BlockInputStream(Channels.newInputStream(channel))) {
-			in.read(buffer.array());
+			final byte[] bytes = IOUtils.toByteArray(in);
+			buffer = ByteBuffer.wrap(bytes);
 		}
 		dataBlock.readData(buffer);
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/RawBlockReaderWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/RawBlockReaderWriter.java
@@ -27,35 +27,19 @@ package org.janelia.saalfeldlab.n5;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
-import java.nio.channels.ByteChannel;
-import java.nio.channels.Channels;
-import java.nio.channels.FileChannel;
+import java.io.OutputStream;
 
-import org.apache.commons.io.IOUtils;
-
-public class RawBlockReaderWriter implements BlockReader, BlockWriter {
+public class RawBlockReaderWriter extends AbstractBlockReaderWriter {
 
 	@Override
-	public <T, B extends DataBlock<T>> void read(
-			final B dataBlock,
-			final ByteChannel channel) throws IOException {
+	protected InputStream getInputStream(final InputStream in) throws IOException {
 
-		final ByteBuffer buffer;
-		try (final InputStream in = Channels.newInputStream(channel)) {
-			final byte[] bytes = IOUtils.toByteArray(in);
-			buffer = ByteBuffer.wrap(bytes);
-		}
-		dataBlock.readData(buffer);
+		return in;
 	}
 
 	@Override
-	public <T> void write(
-			final DataBlock<T> dataBlock,
-			final FileChannel channel) throws IOException {
+	protected OutputStream getOutputStream(final OutputStream out) throws IOException {
 
-		final ByteBuffer buffer = dataBlock.toByteBuffer();
-		channel.write(buffer);
-		channel.truncate(channel.position());
+		return out;
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/SerializableArrayDataBlock.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/SerializableArrayDataBlock.java
@@ -49,8 +49,7 @@ public class SerializableArrayDataBlock<T extends Serializable> extends Abstract
             }
             return ByteBuffer.wrap(b.toByteArray());
         } catch (final IOException e) {
-			e.printStackTrace();
-			return null;
+			throw new RuntimeException(e);
 		}
 	}
 
@@ -63,7 +62,7 @@ public class SerializableArrayDataBlock<T extends Serializable> extends Abstract
             		data = (T[])o.readObject();
             }
         } catch (final IOException | ClassNotFoundException e) {
-			e.printStackTrace();
+        	throw new RuntimeException(e);
 		}
 	}
 	

--- a/src/main/java/org/janelia/saalfeldlab/n5/SerializableArrayDataBlock.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/SerializableArrayDataBlock.java
@@ -60,8 +60,7 @@ public class SerializableArrayDataBlock<T extends Serializable> extends Abstract
 
 		try (final ByteArrayInputStream b = new ByteArrayInputStream(buffer.array())) {
             try (final ObjectInputStream o = new ObjectInputStream(b)) {
-            		final T[] readData = (T[])o.readObject();
-            		System.arraycopy(readData, 0, data, 0, Math.max(readData.length, data.length));
+            		data = (T[])o.readObject();
             }
         } catch (final IOException | ClassNotFoundException e) {
 			e.printStackTrace();

--- a/src/main/java/org/janelia/saalfeldlab/n5/XzBlockReaderWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/XzBlockReaderWriter.java
@@ -33,6 +33,7 @@ import java.nio.channels.FileChannel;
 
 import org.apache.commons.compress.compressors.xz.XZCompressorInputStream;
 import org.apache.commons.compress.compressors.xz.XZCompressorOutputStream;
+import org.apache.commons.io.IOUtils;
 
 public class XzBlockReaderWriter implements BlockReader, BlockWriter {
 
@@ -41,9 +42,10 @@ public class XzBlockReaderWriter implements BlockReader, BlockWriter {
 			final B dataBlock,
 			final ByteChannel channel) throws IOException {
 
-		final ByteBuffer buffer = dataBlock.toByteBuffer();
+		final ByteBuffer buffer;
 		try (final XZCompressorInputStream in = new XZCompressorInputStream(Channels.newInputStream(channel))) {
-			in.read(buffer.array());
+			final byte[] bytes = IOUtils.toByteArray(in);
+			buffer = ByteBuffer.wrap(bytes);
 		}
 		dataBlock.readData(buffer);
 	}

--- a/src/test/java/org/janelia/saalfeldlab/n5/SerializableTypeTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/SerializableTypeTest.java
@@ -1,0 +1,149 @@
+package org.janelia.saalfeldlab.n5;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.TreeSet;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SerializableTypeTest {
+
+	static private String testDirPath = System.getProperty("user.home") + "/tmp/n5-test";
+
+	static private String datasetName = "/test/group/dataset";
+
+	static private long[] dimensions = new long[]{100, 200, 300};
+
+	static private int[] blockSize = new int[]{33, 22, 11};
+	
+	static private Random rnd = new Random();
+	
+	@Before
+	public void before() {
+		cleanup();
+	}
+	
+	@After
+	public void after() {
+		cleanup();
+	}
+	
+	private void cleanup() {
+		try {
+			N5.openFSWriter(testDirPath).remove("");
+		} catch (final IOException e) {
+			Assert.fail(e.getMessage());
+		}
+	}
+	
+	@Test
+	public void testString() {
+		
+		final String[] data = new String[DataBlock.getNumElements(blockSize)];
+		for (int i = 0; i < data.length; ++i) {
+			final int len = rnd.nextInt(50);
+			data[i] = RandomStringUtils.randomAlphanumeric(len);
+		}
+		
+		final N5Writer n5 = N5.openFSWriter(testDirPath);
+		for (final CompressionType compressionType : CompressionType.values()) {
+			try {
+				n5.createDataset(datasetName, dimensions, blockSize, DataType.SERIALIZABLE, compressionType);
+				final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
+				
+				final SerializableArrayDataBlock<String> dataBlock = new SerializableArrayDataBlock<>(blockSize, new long[]{0, 0, 0}, data);
+				n5.writeBlock(datasetName, attributes, dataBlock);
+				
+				final DataBlock<?> readDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
+	
+				final String[] readData = new String[readDataBlock.getNumElements()];
+				System.arraycopy(readDataBlock.getData(), 0, readData, 0, readData.length);
+				
+				Assert.assertArrayEquals(data, readData);
+	
+				Assert.assertTrue(n5.remove(datasetName));
+				
+			} catch (final IOException e) {
+				Assert.fail(e.getMessage());
+			}
+		}
+	}
+	
+	@Test
+	public void testHashSet() {
+		
+		@SuppressWarnings("unchecked")
+		final HashSet<Integer>[] data = new HashSet[DataBlock.getNumElements(blockSize)];
+		for (int i = 0; i < data.length; ++i) {
+			data[i] = new HashSet<>();
+			final int cnt = rnd.nextInt(10);
+			for (int j = 0; j < cnt; ++j)
+				data[i].add(rnd.nextInt(100));
+		}
+		
+		final N5Writer n5 = N5.openFSWriter(testDirPath);
+		for (final CompressionType compressionType : CompressionType.values()) {
+			try {
+				n5.createDataset(datasetName, dimensions, blockSize, DataType.SERIALIZABLE, compressionType);
+				final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
+				
+				final SerializableArrayDataBlock<HashSet<Integer>> dataBlock = new SerializableArrayDataBlock<>(blockSize, new long[]{0, 0, 0}, data);
+				n5.writeBlock(datasetName, attributes, dataBlock);
+				
+				final DataBlock<?> readDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
+	
+				@SuppressWarnings("unchecked")
+				final HashSet<Integer>[] readData = new HashSet[readDataBlock.getNumElements()];
+				System.arraycopy(readDataBlock.getData(), 0, readData, 0, readData.length);
+				
+				Assert.assertEquals(data.length, readData.length);
+				for (int i = 0; i < data.length; ++i)
+					Assert.assertArrayEquals(new TreeSet<>(data[i]).toArray(), new TreeSet<>(readData[i]).toArray());
+	
+				Assert.assertTrue(n5.remove(datasetName));
+				
+			} catch (final IOException e) {
+				Assert.fail(e.getMessage());
+			}
+		}
+	}
+	
+	@Test
+	public void testBigInteger() {
+		
+		final BigInteger[] data = new BigInteger[DataBlock.getNumElements(blockSize)];
+		for (int i = 0; i < data.length; ++i) {
+			final int bits = rnd.nextInt(256) + 128;
+			data[i] = new BigInteger(bits, rnd);
+		}
+		
+		final N5Writer n5 = N5.openFSWriter(testDirPath);
+		for (final CompressionType compressionType : CompressionType.values()) {
+			try {
+				n5.createDataset(datasetName, dimensions, blockSize, DataType.SERIALIZABLE, compressionType);
+				final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
+				
+				final SerializableArrayDataBlock<BigInteger> dataBlock = new SerializableArrayDataBlock<>(blockSize, new long[]{0, 0, 0}, data);
+				n5.writeBlock(datasetName, attributes, dataBlock);
+				
+				final DataBlock<?> readDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
+	
+				final BigInteger[] readData = new BigInteger[readDataBlock.getNumElements()];
+				System.arraycopy(readDataBlock.getData(), 0, readData, 0, readData.length);
+				
+				Assert.assertArrayEquals(data, readData);
+	
+				Assert.assertTrue(n5.remove(datasetName));
+				
+			} catch (final IOException e) {
+				Assert.fail(e.getMessage());
+			}
+		}
+	}
+}

--- a/src/test/java/org/janelia/saalfeldlab/n5/SerializableTypeTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/SerializableTypeTest.java
@@ -62,9 +62,7 @@ public class SerializableTypeTest {
 				
 				final DataBlock<?> readDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
 	
-				final String[] readData = new String[readDataBlock.getNumElements()];
-				System.arraycopy(readDataBlock.getData(), 0, readData, 0, readData.length);
-				
+				final String[] readData = (String[])readDataBlock.getData();
 				Assert.assertArrayEquals(data, readData);
 	
 				Assert.assertTrue(n5.remove(datasetName));
@@ -99,9 +97,7 @@ public class SerializableTypeTest {
 				final DataBlock<?> readDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
 	
 				@SuppressWarnings("unchecked")
-				final HashSet<Integer>[] readData = new HashSet[readDataBlock.getNumElements()];
-				System.arraycopy(readDataBlock.getData(), 0, readData, 0, readData.length);
-				
+				final HashSet<Integer>[] readData = (HashSet[])readDataBlock.getData();
 				Assert.assertEquals(data.length, readData.length);
 				for (int i = 0; i < data.length; ++i)
 					Assert.assertArrayEquals(new TreeSet<>(data[i]).toArray(), new TreeSet<>(readData[i]).toArray());
@@ -134,9 +130,7 @@ public class SerializableTypeTest {
 				
 				final DataBlock<?> readDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
 	
-				final BigInteger[] readData = new BigInteger[readDataBlock.getNumElements()];
-				System.arraycopy(readDataBlock.getData(), 0, readData, 0, readData.length);
-				
+				final BigInteger[] readData = (BigInteger[])readDataBlock.getData();
 				Assert.assertArrayEquals(data, readData);
 	
 				Assert.assertTrue(n5.remove(datasetName));


### PR DESCRIPTION
This PR adds support for datasets of arbitrary serializable type.
Data blocks are stored as arrays, and their elements are required to be `Serializable`. Java serialization is used for now, but can be switched to something more sophisticated (e.g. Kryo).
The [test](https://github.com/igorpisarev/n5/blob/30fc21b2aa03be6e70bbe24e3e89dbb6421f64ae/src/test/java/org/janelia/saalfeldlab/n5/SerializableTypeTest.java) has examples of using this mechanism with `String`, `HashSet<Integer>` and `BigInteger`.