### PR TITLE
Fix N5FSWriter not writing numElements in mode=1

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
@@ -239,15 +239,16 @@ public class N5FSWriter extends N5FSReader implements N5Writer {
 			final FileLock lock = channel.lock();
 			final DataOutputStream dos = new DataOutputStream(out);
 			
-			if (dataBlock.getNumElements() == DataBlock.getNumElements(dataBlock.getSize()))
-				dos.writeShort(0);
-			else
-				dos.writeShort(1);
+			int mode = (dataBlock.getNumElements() == DataBlock.getNumElements(dataBlock.getSize())) ? 0 : 1; 
+			dos.writeShort(mode);
 			
 			dos.writeShort(datasetAttributes.getNumDimensions());
 			for (final int size : dataBlock.getSize())
 				dos.writeInt(size);
 
+			if(mode != 0)
+				dos.writeInt(dataBlock.getNumElements());
+			
 			dos.flush();
 
 			final BlockWriter writer = datasetAttributes.getCompressionType().getWriter();

--- a/src/test/java/org/janelia/saalfeldlab/n5/N5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/N5Test.java
@@ -307,6 +307,37 @@ public class N5Test {
 			}
 		}
 	}
+	
+	@Test
+	public void testMode1WriteReadByteBlock() {
+
+		int[] differentBlockSize = new int[] {5, 10, 15};
+		
+		for (final CompressionType compressionType : CompressionType.values()) {
+			for (final DataType dataType : new DataType[]{
+					DataType.UINT8,
+					DataType.INT8}) {
+
+				System.out.println("Testing " + compressionType + " " + dataType + " (mode=1)");
+				try {
+					n5.createDataset(datasetName, dimensions, differentBlockSize, dataType, compressionType);
+					final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
+					final ByteArrayDataBlock dataBlock = new ByteArrayDataBlock(differentBlockSize, new long[]{0, 0, 0}, byteBlock);
+					n5.writeBlock(datasetName, attributes, dataBlock);
+
+					final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
+
+					Assert.assertArrayEquals(byteBlock, (byte[])loadedDataBlock.getData());
+
+					Assert.assertTrue(n5.remove(datasetName));
+
+				} catch (final IOException e) {
+					e.printStackTrace();
+					fail("Block cannot be written.");
+				}
+			}
+		}
+	}
 
 	@Test
 	public void testRemove() {


### PR DESCRIPTION
When the mode is 1 (determined automatically by the `N5FSWriter` depending on whether `numElements` equals `getNumElements(getSize())`), `numElements` should have been written after the dimensions and before the data, as [specified](https://github.com/saalfeldlab/n5#specifications), and as `N5FSReader` [expects](https://github.com/saalfeldlab/n5/blob/master/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java#L236). Also adds a test case to make sure this functionality isn't broken by a future change.