### PR TITLE
Default block readers/writers

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/BlockReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/BlockReader.java
@@ -26,22 +26,22 @@
 package org.janelia.saalfeldlab.n5;
 
 import java.io.IOException;
-import java.nio.channels.ReadableByteChannel;
+import java.io.InputStream;
 
 /**
- * Interface for block readers that can read a {@link DataBlock} from a
- * {@link ReadableByteChannel}.
+ * Interface for block readers that can read a {@link DataBlock} from an
+ * {@link InputStream}.
  *
  * @author Stephan Saalfeld
  */
 public interface BlockReader {
 
 	/**
-	 * Reads a {@link DataBlock} from a {@link ReadableByteChannel}.
+	 * Reads a {@link DataBlock} from an {@link InputStream}.
 	 *
 	 * @param dataBlock
-	 * @param channel
+	 * @param in
 	 * @throws IOException
 	 */
-	public <T, B extends DataBlock<T>> void read(final B dataBlock, final ReadableByteChannel channel) throws IOException;
+	public <T, B extends DataBlock<T>> void read(final B dataBlock, final InputStream in) throws IOException;
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/BlockWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/BlockWriter.java
@@ -26,22 +26,22 @@
 package org.janelia.saalfeldlab.n5;
 
 import java.io.IOException;
-import java.nio.channels.WritableByteChannel;
+import java.io.OutputStream;
 
 /**
- * Interface for block writers that can write a {@link DataBlock} into a
- * {@link WritableByteChannel}.
+ * Interface for block writers that can write a {@link DataBlock} into an
+ * {@link OutputStream}.
  *
  * @author Stephan Saalfeld
  */
 public interface BlockWriter {
 
 	/**
-	 * Writes a {@link DataBlock} into a {@link WritableByteChannel}.
+	 * Writes a {@link DataBlock} into an {@link OutputStream}.
 	 *
 	 * @param dataBlock
-	 * @param channel
+	 * @param out
 	 * @throws IOException
 	 */
-	public <T> void write(final DataBlock<T> dataBlock, final WritableByteChannel channel) throws IOException;
+	public <T> void write(final DataBlock<T> dataBlock, final OutputStream out) throws IOException;
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/DefaultBlockReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/DefaultBlockReader.java
@@ -51,4 +51,39 @@ public interface DefaultBlockReader extends BlockReader {
 		}
 		dataBlock.readData(buffer);
 	}
+
+	/**
+	 * Reads a {@link DataBlock} from an {@link InputStream}.
+	 *
+	 * @param in
+	 * @param datasetAttributes
+	 * @param gridPosition
+	 * @return
+	 * @throws IOException
+	 */
+	public static DataBlock<?> readBlock(
+			final InputStream in,
+			final DatasetAttributes datasetAttributes,
+			final long[] gridPosition) throws IOException {
+
+		final DataInputStream dis = new DataInputStream(in);
+		final short mode = dis.readShort();
+		final int nDim = dis.readShort();
+		final int[] blockSize = new int[nDim];
+		for (int d = 0; d < nDim; ++d)
+			blockSize[d] = dis.readInt();
+		final int numElements;
+		switch (mode) {
+		case 1:
+			numElements = dis.readInt();
+			break;
+		default:
+			numElements = DataBlock.getNumElements(blockSize);
+		}
+		final DataBlock<?> dataBlock = datasetAttributes.getDataType().createDataBlock(blockSize, gridPosition, numElements);
+
+		final BlockReader reader = datasetAttributes.getCompressionType().getReader();
+		reader.read(dataBlock, in);
+		return dataBlock;
+	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/DefaultBlockReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/DefaultBlockReader.java
@@ -25,11 +25,10 @@
  */
 package org.janelia.saalfeldlab.n5;
 
+import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.nio.channels.Channels;
-import java.nio.channels.ReadableByteChannel;
 
 /**
  * Default implementation of {@link BlockReader}.
@@ -44,11 +43,11 @@ public interface DefaultBlockReader extends BlockReader {
 	@Override
 	public default <T, B extends DataBlock<T>> void read(
 			final B dataBlock,
-			final ReadableByteChannel channel) throws IOException {
+			final InputStream in) throws IOException {
 
 		final ByteBuffer buffer = dataBlock.toByteBuffer();
-		try (final InputStream in = getInputStream(Channels.newInputStream(channel))) {
-			in.read(buffer.array());
+		try (final InputStream inflater = getInputStream(in)) {
+			inflater.read(buffer.array());
 		}
 		dataBlock.readData(buffer);
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/DefaultBlockReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/DefaultBlockReader.java
@@ -47,7 +47,8 @@ public interface DefaultBlockReader extends BlockReader {
 
 		final ByteBuffer buffer = dataBlock.toByteBuffer();
 		try (final InputStream inflater = getInputStream(in)) {
-			inflater.read(buffer.array());
+			final DataInputStream dis = new DataInputStream(inflater);
+			dis.readFully(buffer.array());
 		}
 		dataBlock.readData(buffer);
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/DefaultBlockWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/DefaultBlockWriter.java
@@ -25,11 +25,10 @@
  */
 package org.janelia.saalfeldlab.n5;
 
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.nio.channels.Channels;
-import java.nio.channels.WritableByteChannel;
 
 /**
  * Default implementation of {@link BlockWriter}.
@@ -44,12 +43,12 @@ public interface DefaultBlockWriter extends BlockWriter {
 	@Override
 	public default <T> void write(
 			final DataBlock<T> dataBlock,
-			final WritableByteChannel channel) throws IOException {
+			final OutputStream out) throws IOException {
 
 		final ByteBuffer buffer = dataBlock.toByteBuffer();
-		try (final OutputStream out = getOutputStream(Channels.newOutputStream(channel))) {
-			out.write(buffer.array());
-			out.flush();
+		try (final OutputStream deflater = getOutputStream(out)) {
+			deflater.write(buffer.array());
+			deflater.flush();
 		}
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/DefaultBlockWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/DefaultBlockWriter.java
@@ -51,4 +51,35 @@ public interface DefaultBlockWriter extends BlockWriter {
 			deflater.flush();
 		}
 	}
+
+	/**
+	 * Writes a {@link DataBlock} into an {@link OutputStream}.
+	 *
+	 * @param out
+	 * @param datasetAttributes
+	 * @param dataBlock
+	 * @throws IOException
+	 */
+	public static <T> void writeBlock(
+			final OutputStream out,
+			final DatasetAttributes datasetAttributes,
+			final DataBlock<T> dataBlock) throws IOException {
+
+		final DataOutputStream dos = new DataOutputStream(out);
+
+		final int mode = (dataBlock.getNumElements() == DataBlock.getNumElements(dataBlock.getSize())) ? 0 : 1;
+		dos.writeShort(mode);
+
+		dos.writeShort(datasetAttributes.getNumDimensions());
+		for (final int size : dataBlock.getSize())
+			dos.writeInt(size);
+
+		if (mode != 0)
+			dos.writeInt(dataBlock.getNumElements());
+
+		dos.flush();
+
+		final BlockWriter writer = datasetAttributes.getCompressionType().getWriter();
+		writer.write(dataBlock, out);
+	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/DefaultBlockWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/DefaultBlockWriter.java
@@ -37,7 +37,7 @@ import java.nio.channels.WritableByteChannel;
  * @author Stephan Saalfeld
  * @author Igor Pisarev
  */
-interface DefaultBlockWriter extends BlockWriter {
+public interface DefaultBlockWriter extends BlockWriter {
 
 	public OutputStream getOutputStream(final OutputStream out) throws IOException;
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
@@ -213,7 +213,7 @@ public class N5FSReader implements DefaultGsonReader {
 		final DataBlock<?> dataBlock = datasetAttributes.getDataType().createDataBlock(blockSize, gridPosition, numElements);
 
 		final BlockReader reader = datasetAttributes.getCompressionType().getReader();
-		reader.read(dataBlock, channel);
+		reader.read(dataBlock, Channels.newInputStream(channel));
 		return dataBlock;
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
@@ -178,6 +178,6 @@ public class N5FSWriter extends N5FSReader implements DefaultGsonReader, N5Write
 		dos.flush();
 
 		final BlockWriter writer = datasetAttributes.getCompressionType().getWriter();
-		writer.write(dataBlock, channel);
+		writer.write(dataBlock, Channels.newOutputStream(channel));
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
@@ -81,12 +81,6 @@ public class N5FSWriter extends N5FSReader implements DefaultGsonReader, N5Write
 	}
 
 	@Override
-	public boolean remove() throws IOException {
-
-		return remove("");
-	}
-
-	@Override
 	public void createGroup(final String pathName) throws IOException {
 
 		final Path path = Paths.get(basePath, pathName);
@@ -122,6 +116,12 @@ public class N5FSWriter extends N5FSReader implements DefaultGsonReader, N5Write
 			lockedChannel.getFileChannel().truncate(0);
 			writeBlock(lockedChannel.getFileChannel(), datasetAttributes, dataBlock);
 		}
+	}
+
+	@Override
+	public boolean remove() throws IOException {
+
+		return remove("");
 	}
 
 	@Override

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -44,7 +44,7 @@ public abstract class AbstractN5Test {
 	static private final String[] subGroupNames = new String[]{"a", "b", "c"};
 	static private final String datasetName = "/test/group/dataset";
 	static private final long[] dimensions = new long[]{100, 200, 300};
-	static private final int[] blockSize = new int[]{33, 22, 11};
+	static private final int[] blockSize = new int[]{44, 33, 22};
 
 	static private byte[] byteBlock;
 	static private short[] shortBlock;

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -85,7 +85,7 @@ public abstract class AbstractN5Test {
 	@AfterClass
 	public static void rampDownAfterClass() throws IOException {
 
-		n5.remove();
+		Assert.assertTrue(n5.remove());
 	}
 
 	@Test


### PR DESCRIPTION
- Changed default block readers/writers to work with IO streams instead of NIO channels
- Moved block metadata handling to default block readers/writers
- Fixed the issue with incomplete buffer reading #12