### PR TITLE
AbstractGsonReader

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/AbstractGsonReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/AbstractGsonReader.java
@@ -40,17 +40,17 @@ import com.google.gson.JsonElement;
  * @author Stephan Saalfeld
  * @author Igor Pisarev
  */
-public abstract class DefaultGsonReader implements GsonAttributesParser, N5Reader {
+public abstract class AbstractGsonReader implements GsonAttributesParser, N5Reader {
 
 	protected final Gson gson;
 
 	/**
-	 * Constructs an {@link DefaultGsonReader} with a custom
+	 * Constructs an {@link AbstractGsonReader} with a custom
 	 * {@link GsonBuilder} to support custom attributes.
 	 *
 	 * @param gsonBuilder
 	 */
-	public DefaultGsonReader(final GsonBuilder gsonBuilder) {
+	public AbstractGsonReader(final GsonBuilder gsonBuilder) {
 
 		gsonBuilder.registerTypeAdapter(DataType.class, new DataType.JsonAdapter());
 		gsonBuilder.registerTypeAdapter(CompressionType.class, new CompressionType.JsonAdapter());
@@ -58,10 +58,10 @@ public abstract class DefaultGsonReader implements GsonAttributesParser, N5Reade
 	}
 
 	/**
-	 * Constructs an {@link DefaultGsonReader} with a default
+	 * Constructs an {@link AbstractGsonReader} with a default
 	 * {@link GsonBuilder}.
 	 */
-	public DefaultGsonReader() {
+	public AbstractGsonReader() {
 
 		this(new GsonBuilder());
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/DefaultGsonReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/DefaultGsonReader.java
@@ -30,29 +30,50 @@ import java.util.Arrays;
 import java.util.HashMap;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 
 /**
- * Default implementation of {@link N5Reader} with JSON attributes parsed
- * with {@link Gson}.
+ * Abstract base class implementing {@link N5Reader} with JSON attributes
+ * parsed with {@link Gson}.
  *
  * @author Stephan Saalfeld
  * @author Igor Pisarev
  */
-public interface DefaultGsonReader extends GsonAttributesParser, N5Reader {
+public abstract class DefaultGsonReader implements GsonAttributesParser, N5Reader {
+
+	protected final Gson gson;
 
 	/**
-	 * Reads or creates the attributes map of a group or dataset.
+	 * Constructs an {@link DefaultGsonReader} with a custom
+	 * {@link GsonBuilder} to support custom attributes.
 	 *
-	 * @param pathName group path
-	 * @return
-	 * @throws IOException
+	 * @param gsonBuilder
 	 */
-	@Override
-	public HashMap<String, JsonElement> getAttributes(final String pathName) throws IOException;
+	public DefaultGsonReader(final GsonBuilder gsonBuilder) {
+
+		gsonBuilder.registerTypeAdapter(DataType.class, new DataType.JsonAdapter());
+		gsonBuilder.registerTypeAdapter(CompressionType.class, new CompressionType.JsonAdapter());
+		this.gson = gsonBuilder.create();
+	}
+
+	/**
+	 * Constructs an {@link DefaultGsonReader} with a default
+	 * {@link GsonBuilder}.
+	 */
+	public DefaultGsonReader() {
+
+		this(new GsonBuilder());
+	}
 
 	@Override
-	public default DatasetAttributes getDatasetAttributes(final String pathName) throws IOException {
+	public Gson getGson() {
+
+		return gson;
+	}
+
+	@Override
+	public DatasetAttributes getDatasetAttributes(final String pathName) throws IOException {
 
 		final HashMap<String, JsonElement> map = getAttributes(pathName);
 		final Gson gson = getGson();
@@ -77,7 +98,7 @@ public interface DefaultGsonReader extends GsonAttributesParser, N5Reader {
 	}
 
 	@Override
-	public default <T> T getAttribute(
+	public <T> T getAttribute(
 			final String pathName,
 			final String key,
 			final Class<T> clazz) throws IOException {

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.OverlappingFileLockException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
@@ -137,7 +138,7 @@ public class N5FSReader extends AbstractGsonReader {
 			return new HashMap<>();
 
 		try (final LockedFileChannel lockedFileChannel = LockedFileChannel.openForReading(path)) {
-			return GsonAttributesParser.readAttributes(Channels.newReader(lockedFileChannel.getFileChannel(), "UTF-8"), getGson());
+			return GsonAttributesParser.readAttributes(Channels.newReader(lockedFileChannel.getFileChannel(), StandardCharsets.UTF_8.name()), getGson());
 		}
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
@@ -46,7 +46,7 @@ import com.google.gson.JsonElement;
  *
  * @author Stephan Saalfeld
  */
-public class N5FSReader extends DefaultGsonReader {
+public class N5FSReader extends AbstractGsonReader {
 
 	protected static class LockedFileChannel implements Closeable {
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
@@ -38,7 +38,6 @@ import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.stream.Stream;
 
-import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 
@@ -47,7 +46,7 @@ import com.google.gson.JsonElement;
  *
  * @author Stephan Saalfeld
  */
-public class N5FSReader implements DefaultGsonReader {
+public class N5FSReader extends DefaultGsonReader {
 
 	protected static class LockedFileChannel implements Closeable {
 
@@ -96,11 +95,9 @@ public class N5FSReader implements DefaultGsonReader {
 		}
 	}
 
-	protected final String basePath;
-
 	protected static final String jsonFile = "attributes.json";
 
-	protected final Gson gson;
+	protected final String basePath;
 
 	/**
 	 * Opens an {@link N5FSReader} at a given base path with a custom
@@ -111,9 +108,7 @@ public class N5FSReader implements DefaultGsonReader {
 	 */
 	public N5FSReader(final String basePath, final GsonBuilder gsonBuilder) {
 
-		gsonBuilder.registerTypeAdapter(DataType.class, new DataType.JsonAdapter());
-		gsonBuilder.registerTypeAdapter(CompressionType.class, new CompressionType.JsonAdapter());
-		this.gson = gsonBuilder.create();
+		super(gsonBuilder);
 		this.basePath = basePath;
 	}
 
@@ -125,12 +120,6 @@ public class N5FSReader implements DefaultGsonReader {
 	public N5FSReader(final String basePath) {
 
 		this(basePath, new GsonBuilder());
-	}
-
-	@Override
-	public Gson getGson() {
-
-		return gson;
 	}
 
 	@Override
@@ -148,7 +137,7 @@ public class N5FSReader implements DefaultGsonReader {
 			return new HashMap<>();
 
 		try (final LockedFileChannel lockedFileChannel = LockedFileChannel.openForReading(path)) {
-			return GsonAttributesParser.readAttributes(Channels.newReader(lockedFileChannel.getFileChannel(), "UTF-8"), gson);
+			return GsonAttributesParser.readAttributes(Channels.newReader(lockedFileChannel.getFileChannel(), "UTF-8"), getGson());
 		}
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
@@ -184,7 +184,7 @@ public class N5FSReader extends AbstractGsonReader {
 	 * @param gridPosition
 	 * @return
 	 */
-	protected Path getDataBlockPath(
+	protected static Path getDataBlockPath(
 			final String datasetPathName,
 			final long[] gridPosition) {
 
@@ -201,7 +201,7 @@ public class N5FSReader extends AbstractGsonReader {
 	 * @param pathName
 	 * @return
 	 */
-	protected Path getAttributesPath(final String pathName) {
+	protected static Path getAttributesPath(final String pathName) {
 
 		return Paths.get(pathName, jsonFile);
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
@@ -27,6 +27,7 @@ package org.janelia.saalfeldlab.n5;
 
 import java.io.IOException;
 import java.nio.channels.Channels;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -94,11 +95,11 @@ public class N5FSWriter extends N5FSReader implements N5Writer {
 		final HashMap<String, JsonElement> map = new HashMap<>();
 
 		try (final LockedFileChannel lockedFileChannel = LockedFileChannel.openForWriting(path)) {
-			map.putAll(GsonAttributesParser.readAttributes(Channels.newReader(lockedFileChannel.getFileChannel(), "UTF-8"), getGson()));
+			map.putAll(GsonAttributesParser.readAttributes(Channels.newReader(lockedFileChannel.getFileChannel(), StandardCharsets.UTF_8.name()), getGson()));
 			GsonAttributesParser.insertAttributes(map, attributes, gson);
 
 			lockedFileChannel.getFileChannel().truncate(0);
-			GsonAttributesParser.writeAttributes(Channels.newWriter(lockedFileChannel.getFileChannel(), "UTF-8"), map, getGson());
+			GsonAttributesParser.writeAttributes(Channels.newWriter(lockedFileChannel.getFileChannel(), StandardCharsets.UTF_8.name()), map, getGson());
 		}
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
@@ -43,7 +43,7 @@ import com.google.gson.JsonElement;
  *
  * @author Stephan Saalfeld
  */
-public class N5FSWriter extends N5FSReader implements DefaultGsonReader, N5Writer {
+public class N5FSWriter extends N5FSReader implements N5Writer {
 
 	/**
 	 * Opens an {@link N5FSWriter} at a given base path with a custom
@@ -94,11 +94,11 @@ public class N5FSWriter extends N5FSReader implements DefaultGsonReader, N5Write
 		final HashMap<String, JsonElement> map = new HashMap<>();
 
 		try (final LockedFileChannel lockedFileChannel = LockedFileChannel.openForWriting(path)) {
-			map.putAll(GsonAttributesParser.readAttributes(Channels.newReader(lockedFileChannel.getFileChannel(), "UTF-8"), gson));
+			map.putAll(GsonAttributesParser.readAttributes(Channels.newReader(lockedFileChannel.getFileChannel(), "UTF-8"), getGson()));
 			GsonAttributesParser.insertAttributes(map, attributes, gson);
 
 			lockedFileChannel.getFileChannel().truncate(0);
-			GsonAttributesParser.writeAttributes(Channels.newWriter(lockedFileChannel.getFileChannel(), "UTF-8"), map, gson);
+			GsonAttributesParser.writeAttributes(Channels.newWriter(lockedFileChannel.getFileChannel(), "UTF-8"), map, getGson());
 		}
 	}
 


### PR DESCRIPTION
Another small change that I would like to make:
- Moved `gson` object instantiation to `AbstractGsonReader` (formerly `DefaultGsonReader`)

This allows to omit setting up proper type adapters for the mandatory attributes in the implementations.