### PR TITLE
Fix testExists()

### DIFF
--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -421,6 +421,7 @@ public abstract class AbstractN5Test {
 
 		final String groupName2 = groupName + "-2";
 		final String datasetName2 = datasetName + "-2";
+		final String notExists = groupName + "-notexists";
 		try {
 			n5.createDataset(datasetName2, dimensions, blockSize, DataType.UINT64, CompressionType.RAW);
 			Assert.assertTrue(n5.exists(datasetName2));
@@ -429,6 +430,9 @@ public abstract class AbstractN5Test {
 			n5.createGroup(groupName2);
 			Assert.assertTrue(n5.exists(groupName2));
 			Assert.assertFalse(n5.datasetExists(groupName2));
+
+			Assert.assertFalse(n5.exists(notExists));
+			Assert.assertFalse(n5.datasetExists(notExists));
 		} catch (final IOException e) {
 			fail(e.getMessage());
 		}

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -429,7 +429,6 @@ public abstract class AbstractN5Test {
 			n5.createGroup(groupName2);
 			Assert.assertTrue(n5.exists(groupName2));
 			Assert.assertFalse(n5.datasetExists(groupName2));
-			Assert.assertTrue(n5Parser.getAttributes(groupName2).isEmpty());
 		} catch (final IOException e) {
 			fail(e.getMessage());
 		}


### PR DESCRIPTION
* After `testListAttributes()` has been added, sometimes `testExists()` fails depending on the test execution order. Fix by removing too restrictive assertion that the attributes map is empty
* Add test case to ensure that `n5.exists()` properly returns `false` when a group does not exist