### PR TITLE
Improve tests & versioning

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/AbstractN5FSReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/AbstractN5FSReader.java
@@ -41,14 +41,13 @@ import java.util.stream.Stream;
 
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
-import com.google.gson.JsonPrimitive;
 
 /**
  * Filesystem {@link N5Reader} implementation without version compatibility test.
  *
  * @author Stephan Saalfeld
  */
-public abstract class AbstractN5FSReader extends AbstractGsonReader {
+public abstract class AbstractN5FSReader extends AbstractGsonReader implements N5Reader {
 
 	protected static class LockedFileChannel implements Closeable {
 
@@ -212,16 +211,5 @@ public abstract class AbstractN5FSReader extends AbstractGsonReader {
 	protected static Path getAttributesPath(final String pathName) {
 
 		return Paths.get(pathName, jsonFile);
-	}
-
-	protected static Class<?> classForJsonPrimitive(final JsonPrimitive jsonPrimitive) {
-
-		if (jsonPrimitive.isBoolean())
-			return boolean.class;
-		else if (jsonPrimitive.isNumber())
-			return double.class;
-		else if (jsonPrimitive.isString())
-			return String.class;
-		else return Object.class;
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
@@ -34,7 +34,7 @@ import com.google.gson.GsonBuilder;
  *
  * @author Stephan Saalfeld
  */
-public class N5FSReader extends AbstractN5FSReader {
+public class N5FSReader extends AbstractN5FSReader implements N5VersionedReader {
 
 	/**
 	 * Opens an {@link N5FSReader} at a given base path with a custom
@@ -52,10 +52,7 @@ public class N5FSReader extends AbstractN5FSReader {
 	public N5FSReader(final String basePath, final GsonBuilder gsonBuilder) throws IOException, NumberFormatException {
 
 		super(basePath, gsonBuilder);
-
-		int[] version = getVersion();
-		if (!N5Reader.isCompatible(version[0], version[1], version[2]))
-			throw new IOException("Incompatible version " + getAttribute("/", "version", String.class) + " (this is " + VERSION + ").");
+		checkVersion();
 	}
 
 	/**

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
@@ -40,11 +40,11 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 
 /**
- * Filesystem N5Writer implementation with version compatibility check.
+ * Filesystem {@link N5Writer} implementation with version compatibility check.
  *
  * @author Stephan Saalfeld
  */
-public class N5FSWriter extends AbstractN5FSReader implements N5Writer {
+public class N5FSWriter extends N5FSReader implements N5VersionedWriter {
 
 	/**
 	 * Opens an {@link N5FSWriter} at a given base path with a custom
@@ -68,15 +68,8 @@ public class N5FSWriter extends AbstractN5FSReader implements N5Writer {
 	public N5FSWriter(final String basePath, final GsonBuilder gsonBuilder) throws IOException, NumberFormatException {
 
 		super(basePath, gsonBuilder);
-		final Path path = Paths.get(basePath);
-		if (Files.exists(path)) {
-			int[] version = getVersion();
-			if (!N5Reader.isCompatible(version[0], version[1], version[2]))
-				throw new IOException("Incompatible version " + getAttribute("/", "version", String.class) + " (this is " + VERSION + ").");
-		} else
-			Files.createDirectories(path);
-
-		setAttribute("/", "version", VERSION);
+		Files.createDirectories(Paths.get(basePath));
+		setVersion();
 	}
 
 	/**
@@ -97,7 +90,7 @@ public class N5FSWriter extends AbstractN5FSReader implements N5Writer {
 	 * @throws NumberFormatException
 	 *    if the version attribute exists but is malformed.
 	 */
-	public N5FSWriter(final String basePath) throws IOException {
+	public N5FSWriter(final String basePath) throws IOException, NumberFormatException {
 
 		this(basePath, new GsonBuilder());
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
@@ -39,26 +39,6 @@ import java.util.Map;
 public interface N5Reader {
 
 	/**
-	 * Major SemVer version of this N5 spec.
-	 */
-	public static final int VERSION_MAJOR = 2;
-
-	/**
-	 * Minor SemVer version of this N5 spec.
-	 */
-	public static final int VERSION_MINOR = 0;
-
-	/**
-	 * Path SemVar version of this N5 spec.
-	 */
-	public static final int VERSION_PATCH = 0;
-
-	/**
-	 * String representation of the SemVer version of this N5 spec.
-	 */
-	public static final String VERSION = VERSION_MAJOR + "." + VERSION_MINOR + "." + VERSION_PATCH;
-
-	/**
 	 * Reads an attribute.
 	 *
 	 * @param pathName group path
@@ -132,56 +112,4 @@ public interface N5Reader {
 	 * @throws IOException
 	 */
 	public Map<String, Class<?>> listAttributes(final String pathName) throws IOException;
-
-	/**
-	 * /**
-	 * Get the SemVer version [major, minor, patch] of this container
-	 * as specified in the 'version' attribute of the root group.
-	 *
-	 * If no version is specified, 0.0.0 will be returned.
-	 * For incomplete versions, such as 1.2, the missing elements are
-	 * filled with 0, i.e. 1.2.0 in this case.
-	 * If the version does not conform to the "\d+\.\d+\.\d+" format,
-	 * a {@link NumberFormatException} is thrown.
-	 *
-	 * @return
-	 * @throws IOException
-	 * @throws NumberFormatException
-	 */
-	public default int[] getVersion() throws IOException, NumberFormatException {
-
-		String version = getAttribute("/", "version", String.class);
-		final int[] semVer = new int[3];
-		if (version != null) {
-			final String[] components = version.split("\\.");
-			if (components.length > 0)
-				semVer[0] = Integer.parseInt(components[0]);
-			if (components.length > 1)
-				semVer[1] = Integer.parseInt(components[1]);
-			if (components.length > 2)
-				semVer[2] = Integer.parseInt(components[2]);
-		}
-		return semVer;
-	}
-
-	/**
-	 * Returns true if this implementation is compatible with a given version.
-	 *
-	 * Currently, this means that the version is less than or equal to 1.0.0.
-	 *
-	 * @param major
-	 * @param minor
-	 * @param patch
-	 * @return
-	 */
-	public static boolean isCompatible(final int major, final int minor, final int patch) {
-
-		if (major > VERSION_MAJOR)
-			return false;
-		if (minor > VERSION_MINOR)
-			return false;
-		if (patch > VERSION_PATCH)
-			return false;
-		return true;
-	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5VersionedReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5VersionedReader.java
@@ -1,7 +1,40 @@
+/**
+ * Copyright (c) 2017, Stephan Saalfeld
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.janelia.saalfeldlab.n5;
 
 import java.io.IOException;
 
+/**
+ * A simple structured versioned container API for hierarchies
+ * of chunked n-dimensional datasets and attributes.
+ *
+ * {@linkplain https://github.com/axtimwalde/n5}
+ *
+ * @author Stephan Saalfeld
+ */
 public interface N5VersionedReader extends N5Reader {
 
 	/**

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5VersionedReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5VersionedReader.java
@@ -1,0 +1,113 @@
+package org.janelia.saalfeldlab.n5;
+
+import java.io.IOException;
+
+public interface N5VersionedReader extends N5Reader {
+
+	/**
+	 * Major SemVer version of this N5 spec.
+	 */
+	public static final int VERSION_MAJOR = 2;
+
+	/**
+	 * Minor SemVer version of this N5 spec.
+	 */
+	public static final int VERSION_MINOR = 0;
+
+	/**
+	 * Patch SemVar version of this N5 spec.
+	 */
+	public static final int VERSION_PATCH = 0;
+
+	/**
+	 * String representation of the SemVer version of this N5 spec.
+	 */
+	public static final String VERSION = VERSION_MAJOR + "." + VERSION_MINOR + "." + VERSION_PATCH;
+
+	/**
+	 * Version attribute key.
+	 */
+	public static final String VERSION_KEY = "version";
+
+	/**
+	 * Check that this container is compatible
+	 * with the current N5 specification.
+	 *
+	 * @return
+	 * @throws IOException
+	 * @throws NumberFormatException
+	 */
+	public default void checkVersion() throws IOException, NumberFormatException {
+
+		if (exists("/")) {
+			final int[] version = getVersion();
+			if (!isCompatible(version[0], version[1], version[2]))
+				throw new IOException("Incompatible version " + getVersionString() + " (this is " + VERSION + ").");
+		}
+	}
+
+	/**
+	 * Get the SemVer version [major, minor, patch] of this container
+	 * as specified in the 'version' attribute of the root group.
+	 *
+	 * If no version is specified, 0.0.0 will be returned.
+	 * For incomplete versions, such as 1.2, the missing elements are
+	 * filled with 0, i.e. 1.2.0 in this case.
+	 * If the version does not conform to the "\d+\.\d+\.\d+" format,
+	 * a {@link NumberFormatException} is thrown.
+	 *
+	 * @return
+	 * @throws IOException
+	 * @throws NumberFormatException
+	 */
+	public default int[] getVersion() throws IOException, NumberFormatException {
+
+		final String version = getVersionString();
+		final int[] semVer = new int[3];
+		if (version != null) {
+			final String[] components = version.split("\\.");
+			if (components.length > 0)
+				semVer[0] = Integer.parseInt(components[0]);
+			if (components.length > 1)
+				semVer[1] = Integer.parseInt(components[1]);
+			if (components.length > 2)
+				semVer[2] = Integer.parseInt(components[2]);
+		}
+		return semVer;
+	}
+
+	/**
+	 * Get the version string of this container
+	 * as specified in the 'version' attribute of the root group.
+	 *
+	 * If no version is specified, {@code null} will be returned.
+	 *
+	 * @return
+	 * @throws IOException
+	 */
+	public default String getVersionString() throws IOException {
+
+		return getAttribute("/", VERSION_KEY, String.class);
+	}
+
+	/**
+	 * Returns true if this implementation is compatible with a given version.
+	 *
+	 * Currently, this means that the version is less than or equal to 1.0.0.
+	 *
+	 * @param major
+	 * @param minor
+	 * @param patch
+	 * @return
+	 */
+	public static boolean isCompatible(final int major, final int minor, final int patch) {
+
+		if (major > VERSION_MAJOR)
+			return false;
+		if (minor > VERSION_MINOR)
+			return false;
+		if (patch > VERSION_PATCH)
+			return false;
+		return true;
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5VersionedWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5VersionedWriter.java
@@ -1,9 +1,48 @@
+/**
+ * Copyright (c) 2017, Stephan Saalfeld
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.janelia.saalfeldlab.n5;
 
 import java.io.IOException;
 
+/**
+ * A simple structured versioned container API for hierarchies
+ * of chunked n-dimensional datasets and attributes.
+ *
+ * {@linkplain https://github.com/axtimwalde/n5}
+ *
+ * @author Stephan Saalfeld
+ */
 public interface N5VersionedWriter extends N5VersionedReader, N5Writer {
 
+	/**
+	 * Set the version of this container to
+	 * the current N5 specification version.
+	 *
+	 * @throws IOException
+	 */
 	public default void setVersion() throws IOException {
 
 		setAttribute("/", VERSION_KEY, VERSION);

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5VersionedWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5VersionedWriter.java
@@ -1,0 +1,11 @@
+package org.janelia.saalfeldlab.n5;
+
+import java.io.IOException;
+
+public interface N5VersionedWriter extends N5VersionedReader, N5Writer {
+
+	public default void setVersion() throws IOException {
+
+		setAttribute("/", VERSION_KEY, VERSION);
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Writer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Writer.java
@@ -30,7 +30,7 @@ import java.util.Collections;
 import java.util.Map;
 
 /**
- * A simple structured container format for hierarchies of chunked
+ * A simple structured container API for hierarchies of chunked
  * n-dimensional datasets and attributes.
  *
  * {@linkplain https://github.com/axtimwalde/n5}

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -28,12 +28,12 @@ import java.util.Random;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
  * Abstract base class for testing N5 functionality.
- * Subclasses are expected to provide a specific N5 implementation to be tested by defining a custom {@link #setUpBeforeClass()} method.
+ * Subclasses are expected to provide a specific N5 implementation to be tested by defining the {@link #createN5Writer()} method.
  *
  * @author Stephan Saalfeld &lt;saalfelds@janelia.hhmi.org&gt;
  * @author Igor Pisarev &lt;pisarevi@janelia.hhmi.org&gt;
@@ -53,7 +53,10 @@ public abstract class AbstractN5Test {
 	static private float[] floatBlock;
 	static private double[] doubleBlock;
 
-	protected static N5Writer n5;
+	static private N5Writer n5;
+	static private boolean initialized = false;
+
+	protected abstract N5Writer createN5Writer() throws IOException;
 
 	protected Compression[] getCompressions() {
 
@@ -69,8 +72,13 @@ public abstract class AbstractN5Test {
 	/**
 	 * @throws IOException
 	 */
-	@BeforeClass
-	public static void setUpBeforeClass() throws IOException {
+	@Before
+	public void setUpOnce() throws IOException {
+
+		if (initialized)
+			return;
+
+		n5 = createN5Writer();
 
 		final Random rnd = new Random();
 		byteBlock = new byte[blockSize[0] * blockSize[1] * blockSize[2]];
@@ -87,6 +95,8 @@ public abstract class AbstractN5Test {
 			floatBlock[i] = Float.intBitsToFloat(rnd.nextInt());
 			doubleBlock[i] = Double.longBitsToDouble(rnd.nextLong());
 		}
+
+		initialized = true;
 	}
 
 	/**

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -53,7 +53,7 @@ public abstract class AbstractN5Test {
 	static private float[] floatBlock;
 	static private double[] doubleBlock;
 
-	static private N5Writer n5;
+	static protected N5Writer n5;
 	static private boolean initialized = false;
 
 	protected abstract N5Writer createN5Writer() throws IOException;

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -429,6 +429,7 @@ public abstract class AbstractN5Test {
 
 		final String groupName2 = groupName + "-2";
 		final String datasetName2 = datasetName + "-2";
+		final String notExists = groupName + "-notexists";
 		try {
 			n5.createDataset(datasetName2, dimensions, blockSize, DataType.UINT64, new RawCompression());
 			Assert.assertTrue(n5.exists(datasetName2));
@@ -437,6 +438,9 @@ public abstract class AbstractN5Test {
 			n5.createGroup(groupName2);
 			Assert.assertTrue(n5.exists(groupName2));
 			Assert.assertFalse(n5.datasetExists(groupName2));
+
+			Assert.assertFalse(n5.exists(notExists));
+			Assert.assertFalse(n5.datasetExists(notExists));
 		} catch (final IOException e) {
 			fail(e.getMessage());
 		}

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -54,7 +54,6 @@ public abstract class AbstractN5Test {
 	static private double[] doubleBlock;
 
 	protected static N5Writer n5;
-	protected static GsonAttributesParser n5Parser;
 
 	private static final Compression[] compressions = {
 			new RawCompression(),
@@ -364,14 +363,14 @@ public abstract class AbstractN5Test {
 			n5.createGroup(groupName);
 
 			n5.setAttribute(groupName, "key1", "value1");
-			Assert.assertEquals(1, n5Parser.getAttributes(groupName).size());
+			Assert.assertEquals(1, n5.listAttributes(groupName).size());
 			Assert.assertEquals("value1", n5.getAttribute(groupName, "key1", String.class));
 
 			final Map<String, String> newAttributes = new HashMap<>();
 			newAttributes.put("key2", "value2");
 			newAttributes.put("key3", "value3");
 			n5.setAttributes(groupName, newAttributes);
-			Assert.assertEquals(3, n5Parser.getAttributes(groupName).size());
+			Assert.assertEquals(3, n5.listAttributes(groupName).size());
 			Assert.assertEquals("value1", n5.getAttribute(groupName, "key1", String.class));
 			Assert.assertEquals("value2", n5.getAttribute(groupName, "key2", String.class));
 			Assert.assertEquals("value3", n5.getAttribute(groupName, "key3", String.class));
@@ -379,7 +378,7 @@ public abstract class AbstractN5Test {
 			// test the case where the resulting file becomes shorter
 			n5.setAttribute(groupName, "key1", new Integer(1));
 			n5.setAttribute(groupName, "key2", new Integer(2));
-			Assert.assertEquals(3, n5Parser.getAttributes(groupName).size());
+			Assert.assertEquals(3, n5.listAttributes(groupName).size());
 			Assert.assertEquals(new Integer(1), n5.getAttribute(groupName, "key1", Integer.class));
 			Assert.assertEquals(new Integer(2), n5.getAttribute(groupName, "key2", Integer.class));
 			Assert.assertEquals("value3", n5.getAttribute(groupName, "key3", String.class));

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -437,7 +437,6 @@ public abstract class AbstractN5Test {
 			n5.createGroup(groupName2);
 			Assert.assertTrue(n5.exists(groupName2));
 			Assert.assertFalse(n5.datasetExists(groupName2));
-			Assert.assertTrue(n5Parser.getAttributes(groupName2).isEmpty());
 		} catch (final IOException e) {
 			fail(e.getMessage());
 		}

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -40,11 +40,11 @@ import org.junit.Test;
  */
 public abstract class AbstractN5Test {
 
-	static private final String groupName = "/test/group";
-	static private final String[] subGroupNames = new String[]{"a", "b", "c"};
-	static private final String datasetName = "/test/group/dataset";
-	static private final long[] dimensions = new long[]{100, 200, 300};
-	static private final int[] blockSize = new int[]{44, 33, 22};
+	static protected final String groupName = "/test/group";
+	static protected final String[] subGroupNames = new String[]{"a", "b", "c"};
+	static protected final String datasetName = "/test/group/dataset";
+	static protected final long[] dimensions = new long[]{100, 200, 300};
+	static protected final int[] blockSize = new int[]{44, 33, 22};
 
 	static private byte[] byteBlock;
 	static private short[] shortBlock;

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -55,13 +55,16 @@ public abstract class AbstractN5Test {
 
 	protected static N5Writer n5;
 
-	private static final Compression[] compressions = {
-			new RawCompression(),
-			new Bzip2Compression(),
-			new GzipCompression(),
-			new Lz4Compression(),
-			new XzCompression()
-	};
+	protected Compression[] getCompressions() {
+
+		return new Compression[] {
+				new RawCompression(),
+				new Bzip2Compression(),
+				new GzipCompression(),
+				new Lz4Compression(),
+				new XzCompression()
+			};
+	}
 
 	/**
 	 * @throws IOException
@@ -137,7 +140,7 @@ public abstract class AbstractN5Test {
 	@Test
 	public void testWriteReadByteBlock() {
 
-		for (final Compression compression : compressions) {
+		for (final Compression compression : getCompressions()) {
 			for (final DataType dataType : new DataType[]{
 					DataType.UINT8,
 					DataType.INT8}) {
@@ -166,7 +169,7 @@ public abstract class AbstractN5Test {
 	@Test
 	public void testWriteReadShortBlock() {
 
-		for (final Compression compression : compressions) {
+		for (final Compression compression : getCompressions()) {
 			for (final DataType dataType : new DataType[]{
 					DataType.UINT16,
 					DataType.INT16}) {
@@ -195,7 +198,7 @@ public abstract class AbstractN5Test {
 	@Test
 	public void testWriteReadIntBlock() {
 
-		for (final Compression compression : compressions) {
+		for (final Compression compression : getCompressions()) {
 			for (final DataType dataType : new DataType[]{
 					DataType.UINT32,
 					DataType.INT32}) {
@@ -224,7 +227,7 @@ public abstract class AbstractN5Test {
 	@Test
 	public void testWriteReadLongBlock() {
 
-		for (final Compression compression : compressions) {
+		for (final Compression compression : getCompressions()) {
 			for (final DataType dataType : new DataType[]{
 					DataType.UINT64,
 					DataType.INT64}) {
@@ -253,7 +256,7 @@ public abstract class AbstractN5Test {
 	@Test
 	public void testWriteReadFloatBlock() {
 
-		for (final Compression compression : compressions) {
+		for (final Compression compression : getCompressions()) {
 			System.out.println("Testing " + compression.getType() + " float32");
 			try {
 				n5.createDataset(datasetName, dimensions, blockSize, DataType.FLOAT32, compression);
@@ -278,7 +281,7 @@ public abstract class AbstractN5Test {
 	@Test
 	public void testWriteReadDoubleBlock() {
 
-		for (final Compression compression : compressions) {
+		for (final Compression compression : getCompressions()) {
 			System.out.println("Testing " + compression.getType() + " float64");
 			try {
 				n5.createDataset(datasetName, dimensions, blockSize, DataType.FLOAT64, compression);
@@ -304,7 +307,7 @@ public abstract class AbstractN5Test {
 
 		final int[] differentBlockSize = new int[] {5, 10, 15};
 
-		for (final Compression compression : compressions) {
+		for (final Compression compression : getCompressions()) {
 			for (final DataType dataType : new DataType[]{
 					DataType.UINT8,
 					DataType.INT8}) {

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5VersionedTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5VersionedTest.java
@@ -1,0 +1,30 @@
+package org.janelia.saalfeldlab.n5;
+
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public abstract class AbstractN5VersionedTest extends AbstractN5Test {
+
+	@Override
+	protected abstract N5VersionedWriter createN5Writer() throws IOException;
+
+	@Test
+	public void testVersion() throws NumberFormatException, IOException {
+
+		final N5VersionedWriter n5Versioned = (N5VersionedWriter)n5;
+		n5Versioned.checkVersion();
+
+		Assert.assertEquals(N5VersionedReader.VERSION, n5Versioned.getVersionString());
+
+		Assert.assertArrayEquals(
+				new int[] {
+						N5VersionedReader.VERSION_MAJOR,
+						N5VersionedReader.VERSION_MINOR,
+						N5VersionedReader.VERSION_PATCH
+					},
+				n5Versioned.getVersion()
+			);
+	}
+}

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5VersionedTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5VersionedTest.java
@@ -1,3 +1,19 @@
+/**
+ * License: GPL
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
 package org.janelia.saalfeldlab.n5;
 
 import java.io.IOException;
@@ -5,6 +21,13 @@ import java.io.IOException;
 import org.junit.Assert;
 import org.junit.Test;
 
+/**
+ * Abstract base class for testing versioned N5 functionality.
+ * Subclasses are expected to provide a specific N5 implementation to be tested by defining the {@link #createN5Writer()} method.
+ *
+ * @author Stephan Saalfeld &lt;saalfelds@janelia.hhmi.org&gt;
+ * @author Igor Pisarev &lt;pisarevi@janelia.hhmi.org&gt;
+ */
 public abstract class AbstractN5VersionedTest extends AbstractN5Test {
 
 	@Override

--- a/src/test/java/org/janelia/saalfeldlab/n5/N5FSTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/N5FSTest.java
@@ -37,7 +37,6 @@ public class N5FSTest extends AbstractN5Test {
 	public static void setUpBeforeClass() throws IOException {
 
 		n5 = new N5FSWriter(testDirPath);
-		n5Parser = (GsonAttributesParser)n5;
 		AbstractN5Test.setUpBeforeClass();
 	}
 }

--- a/src/test/java/org/janelia/saalfeldlab/n5/N5FSTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/N5FSTest.java
@@ -18,8 +18,6 @@ package org.janelia.saalfeldlab.n5;
 
 import java.io.IOException;
 
-import org.junit.BeforeClass;
-
 /**
  * Initiates testing of the filesystem-based N5 implementation.
  *
@@ -33,10 +31,9 @@ public class N5FSTest extends AbstractN5Test {
 	/**
 	 * @throws IOException
 	 */
-	@BeforeClass
-	public static void setUpBeforeClass() throws IOException {
+	@Override
+	protected N5Writer createN5Writer() throws IOException {
 
-		n5 = new N5FSWriter(testDirPath);
-		AbstractN5Test.setUpBeforeClass();
+		return new N5FSWriter(testDirPath);
 	}
 }

--- a/src/test/java/org/janelia/saalfeldlab/n5/N5FSTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/N5FSTest.java
@@ -24,7 +24,7 @@ import java.io.IOException;
  * @author Stephan Saalfeld &lt;saalfelds@janelia.hhmi.org&gt;
  * @author Igor Pisarev &lt;pisarevi@janelia.hhmi.org&gt;
  */
-public class N5FSTest extends AbstractN5Test {
+public class N5FSTest extends AbstractN5VersionedTest {
 
 	static private String testDirPath = System.getProperty("user.home") + "/tmp/n5-test";
 
@@ -32,7 +32,7 @@ public class N5FSTest extends AbstractN5Test {
 	 * @throws IOException
 	 */
 	@Override
-	protected N5Writer createN5Writer() throws IOException {
+	protected N5VersionedWriter createN5Writer() throws IOException {
 
 		return new N5FSWriter(testDirPath);
 	}


### PR DESCRIPTION
This PR allows to easily support versioning functionality in derived N5 implementations and to use the abstract test set for testing non-json based N5 implementations.

* Add new interfaces `N5VersionedReader` and `N5VersionedWriter`
* Remove `GsonAttributesParser` dependency in `AbstractN5Test`
* Add versioning test
* Fix `testExists()` by removing too restrictive assertion that depended on particular execution order
* Add test case to ensure that `n5.exists()` properly returns `false` when a group does not exist