### PR TITLE
Do not throw IOException when unable to acquire file lock

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
@@ -80,7 +80,7 @@ public class N5FSReader extends AbstractGsonReader {
 						waiting = false;
 						f.printStackTrace(System.err);
 					}
-				}
+				} catch (final IOException e) {}
 			}
 		}
 


### PR DESCRIPTION
On some file systems a file lock cannot be acquired when the directory is not writable (for example, SMB lock). Do not fail in this case and proceed without locking as a fallback.