### PR TITLE
Fix unnecessary version overwriting when versions are equal

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
@@ -67,7 +67,8 @@ public class N5FSWriter extends N5FSReader implements N5Writer {
 
 		super(basePath, gsonBuilder);
 		Files.createDirectories(Paths.get(basePath));
-		setAttribute("/", VERSION_KEY, VERSION.toString());
+		if (!VERSION.equals(getVersion()))
+			setAttribute("/", VERSION_KEY, VERSION.toString());
 	}
 
 	/**


### PR DESCRIPTION
Prevents the following issues when using N5Writer in a parallel environment where file locking does not work across machines (for example, NFS):
* possible JSON format exception when read by one machine while being written by another machine
* possible corruption of attributes.json file when written simultaneously by multiple machines