### PR TITLE
Fix N5 initialization when running multiple tests

### DIFF
--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -107,6 +107,8 @@ public abstract class AbstractN5Test {
 	public static void rampDownAfterClass() throws IOException {
 
 		Assert.assertTrue(n5.remove());
+		initialized = false;
+		n5 = null;
 	}
 
 	@Test


### PR DESCRIPTION
In case of having multiple tests in a single JUnit run that inherit from `N5AbstractTest`, the `n5` instance was initialized only in the first test. As a result, all subsequent tests effectively executed the first test multiple times (for example, in the google cloud package, the mock library might be tested twice instead of testing real google cloud backend for the second time).