### PR TITLE
Bump lz4 dependency to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,9 +83,9 @@
 			<version>1.14</version>
 		</dependency>
 		<dependency>
-			<groupId>net.jpountz.lz4</groupId>
-			<artifactId>lz4</artifactId>
-			<version>1.3.0</version>
+			<groupId>org.lz4</groupId>
+			<artifactId>lz4-java</artifactId>
+			<version>1.4.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
When used with Spark 2.3.1, the old version was causing runtime errors.