### PR TITLE
Support zlib headers in gzip compression

### DIFF
--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -65,6 +65,7 @@ public abstract class AbstractN5Test {
 				new RawCompression(),
 				new Bzip2Compression(),
 				new GzipCompression(),
+				new GzipCompression(5, true),
 				new Lz4Compression(),
 				new XzCompression()
 			};


### PR DESCRIPTION
Quick fix to support reading/writing gzip-compressed data with zlib headers which may be useful for compatibility with other libraries.
`apache-compress` gzip implementation does not seem to support zlib, so the standard java classes are used in this case.
The new parameter `useZlib` is optional and is not written to `attributes.json` by default (when it's `null`).