### PR TITLE
Override N5Reader.toString

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,10 @@
 			<artifactId>commons-compress</artifactId>
 			<version>1.18</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
@@ -41,6 +41,8 @@ import java.util.stream.Stream;
 
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
  * Filesystem {@link N5Reader} implementation with version compatibility check.
@@ -180,6 +182,13 @@ public class N5FSReader extends AbstractGsonReader {
 					.map(a -> path.relativize(a).toString())
 					.toArray(n -> new String[n]);
 		}
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+				.append("basePath", basePath)
+				.toString();
 	}
 
 	/**


### PR DESCRIPTION
This is not meant to be set in stone but rather to spark a discussion on how to override `N5Reader.toString` in a meaningful way. 

The proposed changes print as:
```java
System.out.println(new N5FSWriter(Files.createTempDirectory(null).toString()));
System.out.println(new N5FSReader(Files.createTempDirectory(null).toString()));
```
```
N5FSWriter[basePath=/tmp/3424604478731559346]
N5FSReader[basePath=/tmp/764660700471475069]
```

Fixes #47 