### PR TITLE
Disable html escaping in AbstractGsonReader

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/AbstractGsonReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/AbstractGsonReader.java
@@ -39,6 +39,7 @@ import com.google.gson.JsonElement;
  *
  * @author Stephan Saalfeld
  * @author Igor Pisarev
+ * @author Philipp Hanslovsky
  */
 public abstract class AbstractGsonReader implements GsonAttributesParser, N5Reader {
 
@@ -54,6 +55,7 @@ public abstract class AbstractGsonReader implements GsonAttributesParser, N5Read
 
 		gsonBuilder.registerTypeAdapter(DataType.class, new DataType.JsonAdapter());
 		gsonBuilder.registerTypeHierarchyAdapter(Compression.class, CompressionAdapter.getJsonAdapter());
+		gsonBuilder.disableHtmlEscaping();
 		this.gson = gsonBuilder.create();
 	}
 


### PR DESCRIPTION
This should be considered up for discussion. Do we want to be as restrictive as always disabling html escape? We could be less restrictive and adding a `boolean disableHtmlEscaping` parameter to the constructor that defaults to `true`. Then, callers could still enable html escaping if they wanted to.