### PR TITLE
Improve thread interruption handling in LockedFileChannel

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
@@ -78,7 +78,7 @@ public class N5FSReader extends AbstractGsonReader {
 						Thread.sleep(100);
 					} catch (final InterruptedException f) {
 						waiting = false;
-						f.printStackTrace(System.err);
+						Thread.currentThread().interrupt();
 					}
 				} catch (final IOException e) {}
 			}


### PR DESCRIPTION
I have a use-case where several threads sometimes may read the same N5 block, which leads to generating an `OverlappingFileLockException` and waiting for 100ms before retrying. That works fine, but if the thread is interrupted during that time, annoying error messages were printed. In this PR I removed excessive error printing and also added proper restoring of the interruption flag for the thread, so that the calling code can check it afterwards and handle it appropriately.