### PR TITLE
Override N5FSReader.toString

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
@@ -238,4 +238,9 @@ public class N5FSReader extends AbstractGsonReader {
 
 		return pathName.startsWith("/") || pathName.startsWith("\\") ? pathName.substring(1) : pathName;
 	}
+
+	@Override
+	public String toString() {
+		return String.format("%s[basePath=%s]", getClass().getSimpleName(), basePath);
+	}
 }


### PR DESCRIPTION
Useful for debugging, does not add any additional dependencies (unlike #48)

Closes #47 

cc @axtimwalde 