### PR TITLE
Add compatibility with Java 13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,8 @@
 		<license.projectName>Not HDF5</license.projectName>
 		<license.organizationName>Saalfeld Lab</license.organizationName>
 		<license.copyrightOwners>Stephan Saalfeld</license.copyrightOwners>
+
+		<scijava.jvm.build.version>[1.8.0-101,)</scijava.jvm.build.version>
 	</properties>
 
 	<developers>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 	</ciManagement>
 
 	<properties>
-		<package-name>org.janelia.saalfeldlab</package-name>
+		<package-name>org.janelia.saalfeldlab.n5</package-name>
 
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.projectName>Not HDF5</license.projectName>

--- a/src/main/java/org/janelia/saalfeldlab/n5/CompressionAdapter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/CompressionAdapter.java
@@ -146,24 +146,13 @@ public class CompressionAdapter implements JsonDeserializer<Compression>, JsonSe
 			compression = constructor.newInstance();
 			final Class<? extends Compression> clazz = compression.getClass();
 			final HashMap<String, Class<?>> parameterTypes = compressionParameters.get(type);
-			final Field modifiersField = Field.class.getDeclaredField("modifiers");
-			final boolean isModifiersAccessible = modifiersField.isAccessible();
-			modifiersField.setAccessible(true);
 			for (final Entry<String, Class<?>> parameterType : parameterTypes.entrySet()) {
 				final String name = parameterType.getKey();
 				if (jsonObject.has(name)) {
 					final Object parameter = context.deserialize(jsonObject.get(name), parameterType.getValue());
-					final Field field = clazz.getDeclaredField(name);
-					final boolean isAccessible = field.isAccessible();
-					field.setAccessible(true);
-					final int modifiers = field.getModifiers();
-					modifiersField.setInt(field, modifiers & ~Modifier.FINAL);
-					field.set(compression, parameter);
-					modifiersField.setInt(field, modifiers);
-					field.setAccessible(isAccessible);
+					ReflectionUtils.setFieldValue(compression, name, parameter);
 				}
 			}
-			modifiersField.setAccessible(isModifiersAccessible);
 		} catch (InstantiationException | IllegalAccessException  | IllegalArgumentException | InvocationTargetException | SecurityException | NoSuchFieldException e) {
 			e.printStackTrace(System.err);
 			return null;

--- a/src/main/java/org/janelia/saalfeldlab/n5/GzipCompression.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/GzipCompression.java
@@ -105,18 +105,6 @@ public class GzipCompression implements DefaultBlockReader, DefaultBlockWriter, 
 	private void readObject(final ObjectInputStream in) throws Exception {
 
 		in.defaultReadObject();
-
-		final Field modifiersField = Field.class.getDeclaredField("modifiers");
-		final boolean isModifiersAccessible = modifiersField.isAccessible();
-		modifiersField.setAccessible(true);
-		final Field parametersField = getClass().getDeclaredField("parameters");
-		final boolean isFieldAccessible = parametersField.isAccessible();
-		parametersField.setAccessible(true);
-		final int modifiers = parametersField.getModifiers();
-		modifiersField.setInt(parametersField, modifiers & ~Modifier.FINAL);
-		parametersField.set(this, new GzipParameters());
-		modifiersField.setInt(parametersField, modifiers);
-		parametersField.setAccessible(isFieldAccessible);
-		modifiersField.setAccessible(isModifiersAccessible);
+		ReflectionUtils.setFieldValue(this, "parameters", new GzipParameters());
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/ReflectionUtils.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/ReflectionUtils.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2017, Stephan Saalfeld
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.janelia.saalfeldlab.n5;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+class ReflectionUtils {
+
+	static <T> void setFieldValue(
+			final Object object,
+			final String fieldName,
+			final T value) throws NoSuchFieldException, IllegalAccessException {
+
+		Field modifiersField;
+		boolean isModifiersAccessible;
+		try {
+			modifiersField = Field.class.getDeclaredField("modifiers");
+			isModifiersAccessible = modifiersField.isAccessible();
+			modifiersField.setAccessible(true);
+		} catch (final NoSuchFieldException e) {
+			// Java 11+ does not allow to access modifiers
+			modifiersField = null;
+			isModifiersAccessible = false;
+		}
+
+		final Field field = object.getClass().getDeclaredField(fieldName);
+		final boolean isFieldAccessible = field.isAccessible();
+		field.setAccessible(true);
+
+		if (modifiersField != null) {
+			final int modifiers = field.getModifiers();
+			modifiersField.setInt(field, modifiers & ~Modifier.FINAL);
+			field.set(object, value);
+			modifiersField.setInt(field, modifiers);
+		} else {
+			field.set(object, value);
+		}
+
+		field.setAccessible(isFieldAccessible);
+		if (modifiersField != null) {
+			modifiersField.setAccessible(isModifiersAccessible);
+		}
+	}
+}


### PR DESCRIPTION
The problem with newer versions of Java was that the following exception was thrown at runtime:
`java.lang.NoSuchFieldException: modifiers at java.base/java.lang.Class.getDeclaredField(Class.java:2416)`

The modifiers field is hidden from reflection in Java 11+, but it turns out that it's not necessary anymore to reset the `final` modifier so just setting the field value through reflection works in Oracle JDK 13.