### PR TITLE
Improve initialization and cleanup in AbstractN5Test

### DIFF
--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -55,7 +55,6 @@ public abstract class AbstractN5Test {
 	static private double[] doubleBlock;
 
 	static protected N5Writer n5;
-	static private boolean initialized = false;
 
 	protected abstract N5Writer createN5Writer() throws IOException;
 
@@ -77,7 +76,7 @@ public abstract class AbstractN5Test {
 	@Before
 	public void setUpOnce() throws IOException {
 
-		if (initialized)
+		if (n5 != null)
 			return;
 
 		n5 = createN5Writer();
@@ -97,8 +96,6 @@ public abstract class AbstractN5Test {
 			floatBlock[i] = Float.intBitsToFloat(rnd.nextInt());
 			doubleBlock[i] = Double.longBitsToDouble(rnd.nextLong());
 		}
-
-		initialized = true;
 	}
 
 	/**
@@ -108,7 +105,6 @@ public abstract class AbstractN5Test {
 	public static void rampDownAfterClass() throws IOException {
 
 		Assert.assertTrue(n5.remove());
-		initialized = false;
 		n5 = null;
 	}
 

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -55,8 +55,15 @@ public abstract class AbstractN5Test {
 	static private double[] doubleBlock;
 
 	static protected N5Writer n5;
+	static private AbstractN5Test test;
 
 	protected abstract N5Writer createN5Writer() throws IOException;
+	protected void cleanup() throws IOException {}
+
+	public AbstractN5Test() {
+
+		test = this;
+	}
 
 	protected Compression[] getCompressions() {
 
@@ -80,6 +87,7 @@ public abstract class AbstractN5Test {
 			return;
 
 		n5 = createN5Writer();
+		test = this;
 
 		final Random rnd = new Random();
 		byteBlock = new byte[blockSize[0] * blockSize[1] * blockSize[2]];
@@ -107,6 +115,7 @@ public abstract class AbstractN5Test {
 		if (n5 != null) {
 			Assert.assertTrue(n5.remove());
 			n5 = null;
+			test.cleanup();
 		}
 	}
 

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -55,15 +55,8 @@ public abstract class AbstractN5Test {
 	static private double[] doubleBlock;
 
 	static protected N5Writer n5;
-	static private AbstractN5Test test;
 
 	protected abstract N5Writer createN5Writer() throws IOException;
-	protected void cleanup() throws IOException {}
-
-	public AbstractN5Test() {
-
-		test = this;
-	}
 
 	protected Compression[] getCompressions() {
 
@@ -87,7 +80,6 @@ public abstract class AbstractN5Test {
 			return;
 
 		n5 = createN5Writer();
-		test = this;
 
 		final Random rnd = new Random();
 		byteBlock = new byte[blockSize[0] * blockSize[1] * blockSize[2]];
@@ -115,7 +107,6 @@ public abstract class AbstractN5Test {
 		if (n5 != null) {
 			Assert.assertTrue(n5.remove());
 			n5 = null;
-			test.cleanup();
 		}
 	}
 

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -104,8 +104,10 @@ public abstract class AbstractN5Test {
 	@AfterClass
 	public static void rampDownAfterClass() throws IOException {
 
-		Assert.assertTrue(n5.remove());
-		n5 = null;
+		if (n5 != null) {
+			Assert.assertTrue(n5.remove());
+			n5 = null;
+		}
 	}
 
 	@Test


### PR DESCRIPTION
In my use-case I would like to remove temporary data after all tests are completed which is specific to the test environment. Normally it can be done in a method annotated with `@AfterClass`, but it requires the method to be static which doesn't go well with inheritance.

This PR adds a `cleanup()` method in `AbstractN5Test`. It's empty by default, and the actual test classes may optionally override it to do any additional cleanup if needed.