### PR TITLE
Fix occasional DirectoryNotEmptyException when removing files on NFS

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
@@ -148,21 +148,13 @@ public class N5FSWriter extends N5FSReader implements N5Writer {
 			try (final Stream<Path> pathStream = Files.walk(path)) {
 				pathStream.sorted(Comparator.reverseOrder()).forEach(
 						childPath -> {
-							if (Files.isRegularFile(childPath)) {
-								try (final LockedFileChannel channel = LockedFileChannel.openForWriting(childPath)) {
-									Files.delete(childPath);
-								} catch (final IOException e) {
-									e.printStackTrace();
-								}
-							} else
-								try {
-									Files.delete(childPath);
-								} catch (final IOException e) {
-									e.printStackTrace();
-								}
+							try {
+								Files.delete(childPath);
+							} catch (final IOException e) {
+								e.printStackTrace();
+							}
 						});
 			}
-
 		return !Files.exists(path);
 	}
 


### PR DESCRIPTION
Closes #63
It seems that deleting files under the lock was the cause for `DirectoryNotEmptyException` on a network file system. Presumably the lock file sometimes is not cleared immediately after the actual file is deleted, so the directory cannot be removed because it still contains the temporary lock file. But, the directory contents show up as empty right after the exception is thrown, so it looks like a timing or synchronization issue on the network file system.

Deleting the files without locking solves it. It's probably a very unlikely use case anyway to keep reading/writing the N5 dataset files while deleting it, so I don't think that no locking will be a problem here.