### PR TITLE
Better fix for DirectoryNotEmptyException by re-attempting to delete

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
@@ -28,6 +28,7 @@ package org.janelia.saalfeldlab.n5;
 import java.io.IOException;
 import java.nio.channels.Channels;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
@@ -148,10 +149,31 @@ public class N5FSWriter extends N5FSReader implements N5Writer {
 			try (final Stream<Path> pathStream = Files.walk(path)) {
 				pathStream.sorted(Comparator.reverseOrder()).forEach(
 						childPath -> {
-							try {
-								Files.delete(childPath);
-							} catch (final IOException e) {
-								e.printStackTrace();
+							if (Files.isRegularFile(childPath)) {
+								try (final LockedFileChannel channel = LockedFileChannel.openForWriting(childPath)) {
+									Files.delete(childPath);
+								} catch (final IOException e) {
+									e.printStackTrace();
+								}
+							} else {
+								try {
+									Files.delete(childPath);
+								} catch (final DirectoryNotEmptyException e) {
+									// Even though childPath should be an empty directory, sometimes the deletion fails on network file system
+									// when lock files are not cleared immediately after the leaves have been removed.
+									try {
+										// wait and reattempt
+										Thread.sleep(100);
+										Files.delete(childPath);
+									} catch (final InterruptedException ex) {
+										e.printStackTrace();
+										Thread.currentThread().interrupt();
+									} catch (final IOException ex) {
+										ex.printStackTrace();
+									}
+								} catch (final IOException e) {
+									e.printStackTrace();
+								}
 							}
 						});
 			}


### PR DESCRIPTION
This is another solution for #63 and improves upon #64 by keeping file locking when removing group/dataset. When `DirectoryNotEmptyException` is thrown because of the temporary lock file, it waits for 100ms and re-attempts to delete the directory.
I've tested it and it works well: if it fails for the first time, the re-attempt always succeeds.