### PR TITLE
Default null-check implementation of isBlockDeleted() in unit tests

### DIFF
--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -16,7 +16,11 @@
  */
 package org.janelia.saalfeldlab.n5;
 
-import static org.junit.Assert.fail;
+import org.janelia.saalfeldlab.n5.N5Reader.Version;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -26,14 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
-import org.hamcrest.core.IsEqual;
-import org.hamcrest.core.IsInstanceOf;
-import org.hamcrest.core.IsNot;
-import org.janelia.saalfeldlab.n5.N5Reader.Version;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.fail;
 
 /**
  * Abstract base class for testing N5 functionality.
@@ -529,7 +526,7 @@ public abstract class AbstractN5Test {
 		// block should exist at position1 but not at position2
 		final DataBlock<?> readBlock = n5.readBlock(datasetName, attributes, position1);
 		Assert.assertNotNull(readBlock);
-		Assert.assertThat(readBlock, IsInstanceOf.instanceOf(ByteArrayDataBlock.class));
+		Assert.assertTrue(readBlock instanceof ByteArrayDataBlock);
 		Assert.assertArrayEquals(byteBlock, ((ByteArrayDataBlock) readBlock).getData());
 		Assert.assertTrue(testDeleteIsBlockDeleted(n5.readBlock(datasetName, attributes, position2)));
 

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -543,6 +543,7 @@ public abstract class AbstractN5Test {
 		Assert.assertTrue(testDeleteIsBlockDeleted(n5.readBlock(datasetName, attributes, position2)));
 	}
 
-	protected abstract boolean testDeleteIsBlockDeleted(final DataBlock<?> dataBlock);
-
+	protected boolean testDeleteIsBlockDeleted(final DataBlock<?> dataBlock) {
+		return dataBlock == null;
+	}
 }

--- a/src/test/java/org/janelia/saalfeldlab/n5/N5FSTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/N5FSTest.java
@@ -36,9 +36,4 @@ public class N5FSTest extends AbstractN5Test {
 
 		return new N5FSWriter(testDirPath);
 	}
-
-	@Override
-	protected boolean testDeleteIsBlockDeleted(DataBlock<?> dataBlock) {
-		return dataBlock == null;
-	}
 }


### PR DESCRIPTION
I started updating and testing `n5-aws-s3` and `n5-google-cloud` to support block deletion, and I thought that it would be helpful to make null-check a default implementation of the block existence test in `N5AbstractTest`. All implementations return `null` for a missing block except `n5-hdf5` which is a special case, so instead of repeating the default null-check in every implementation it could be only overridden in `n5-hdf5`.