### PR TITLE
add methods to read and write serializable objects as datablocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Chunked datasets can be sparse, i.e. empty chunks do not need to be stored.
 
 ## File-system specification
 
-*version 2.2.2-SNAPSHOT*
+*version 3.0.0-SNAPSHOT*
 
 N5 group is not a single file but simply a directory on the file system.  Meta-data is stored as a JSON file per each group/ directory.  Tensor datasets can be chunked and chunks are stored as individual files.  This enables parallel reading and writing on a cluster.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Chunked datasets can be sparse, i.e. empty chunks do not need to be stored.
 
 ## File-system specification
 
-*version 3.0.0-SNAPSHOT*
+*version 2.3.0-SNAPSHOT*
 
 N5 group is not a single file but simply a directory on the file system.  Meta-data is stored as a JSON file per each group/ directory.  Tensor datasets can be chunked and chunks are stored as individual files.  This enables parallel reading and writing on a cluster.
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.janelia.saalfeldlab</groupId>
 	<artifactId>n5</artifactId>
-	<version>2.2.2-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 
 	<name>N5</name>
 	<description>Not HDF5</description>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.janelia.saalfeldlab</groupId>
 	<artifactId>n5</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>2.3.0-SNAPSHOT</version>
 
 	<name>N5</name>
 	<description>Not HDF5</description>

--- a/src/main/java/org/janelia/saalfeldlab/n5/AbstractGsonReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/AbstractGsonReader.java
@@ -26,6 +26,7 @@
 package org.janelia.saalfeldlab.n5;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.HashMap;
 
@@ -126,5 +127,15 @@ public abstract class AbstractGsonReader implements GsonAttributesParser, N5Read
 
 		final HashMap<String, JsonElement> map = getAttributes(pathName);
 		return GsonAttributesParser.parseAttribute(map, key, clazz, getGson());
+	}
+
+	@Override
+	public <T> T getAttribute(
+			final String pathName,
+			final String key,
+			final Type type) throws IOException {
+
+		final HashMap<String, JsonElement> map = getAttributes(pathName);
+		return GsonAttributesParser.parseAttribute(map, key, type, getGson());
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/DataType.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/DataType.java
@@ -51,7 +51,8 @@ public enum DataType {
 	INT32("int32", (blockSize, gridPosition, numElements) -> new IntArrayDataBlock(blockSize, gridPosition, new int[numElements])),
 	INT64("int64", (blockSize, gridPosition, numElements) -> new LongArrayDataBlock(blockSize, gridPosition, new long[numElements])),
 	FLOAT32("float32", (blockSize, gridPosition, numElements) -> new FloatArrayDataBlock(blockSize, gridPosition, new float[numElements])),
-	FLOAT64("float64", (blockSize, gridPosition, numElements) -> new DoubleArrayDataBlock(blockSize, gridPosition, new double[numElements]));
+	FLOAT64("float64", (blockSize, gridPosition, numElements) -> new DoubleArrayDataBlock(blockSize, gridPosition, new double[numElements])),
+	OBJECT("object", (blockSize, gridPosition, numElements) -> new ByteArrayDataBlock(blockSize, gridPosition, new byte[numElements]));
 
 	private final String label;
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/DefaultBlockReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/DefaultBlockReader.java
@@ -69,19 +69,23 @@ public interface DefaultBlockReader extends BlockReader {
 
 		final DataInputStream dis = new DataInputStream(in);
 		final short mode = dis.readShort();
-		final int nDim = dis.readShort();
-		final int[] blockSize = new int[nDim];
-		for (int d = 0; d < nDim; ++d)
-			blockSize[d] = dis.readInt();
 		final int numElements;
-		switch (mode) {
-		case 1:
+		final DataBlock<?> dataBlock;
+		if (mode != 2) {
+			final int nDim = dis.readShort();
+			final int[] blockSize = new int[nDim];
+			for (int d = 0; d < nDim; ++d)
+				blockSize[d] = dis.readInt();
+			if (mode == 0) {
+				numElements = DataBlock.getNumElements(blockSize);
+			} else {
+				numElements = dis.readInt();
+			}
+			dataBlock = datasetAttributes.getDataType().createDataBlock(blockSize, gridPosition, numElements);
+		} else {
 			numElements = dis.readInt();
-			break;
-		default:
-			numElements = DataBlock.getNumElements(blockSize);
+			dataBlock = datasetAttributes.getDataType().createDataBlock(null, gridPosition, numElements);
 		}
-		final DataBlock<?> dataBlock = datasetAttributes.getDataType().createDataBlock(blockSize, gridPosition, numElements);
 
 		final BlockReader reader = datasetAttributes.getCompression().getReader();
 		reader.read(dataBlock, in);

--- a/src/main/java/org/janelia/saalfeldlab/n5/DefaultBlockWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/DefaultBlockWriter.java
@@ -56,21 +56,21 @@ public interface DefaultBlockWriter extends BlockWriter {
 	 * Writes a {@link DataBlock} into an {@link OutputStream}.
 	 *
 	 * @param out
-	 * @param datasetAttributes
 	 * @param dataBlock
+	 * @param compression
 	 * @throws IOException
 	 */
 	public static <T> void writeBlock(
 			final OutputStream out,
-			final DatasetAttributes datasetAttributes,
-			final DataBlock<T> dataBlock) throws IOException {
+			final DataBlock<T> dataBlock,
+			final Compression compression) throws IOException {
 
 		final DataOutputStream dos = new DataOutputStream(out);
 
 		final int mode = (dataBlock.getNumElements() == DataBlock.getNumElements(dataBlock.getSize())) ? 0 : 1;
 		dos.writeShort(mode);
 
-		dos.writeShort(datasetAttributes.getNumDimensions());
+		dos.writeShort(dataBlock.getSize().length);
 		for (final int size : dataBlock.getSize())
 			dos.writeInt(size);
 
@@ -79,7 +79,7 @@ public interface DefaultBlockWriter extends BlockWriter {
 
 		dos.flush();
 
-		final BlockWriter writer = datasetAttributes.getCompression().getWriter();
+		final BlockWriter writer = compression.getWriter();
 		writer.write(dataBlock, out);
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/GsonAttributesParser.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/GsonAttributesParser.java
@@ -81,6 +81,28 @@ public interface GsonAttributesParser extends N5Reader {
 	}
 
 	/**
+	 * Parses an attribute from the given attributes map.
+	 *
+	 * @param map
+	 * @param key
+	 * @param type
+	 * @return
+	 * @throws IOException
+	 */
+	public static <T> T parseAttribute(
+			final HashMap<String, JsonElement> map,
+			final String key,
+			final Type type,
+			final Gson gson) throws IOException {
+
+		final JsonElement attribute = map.get(key);
+		if (attribute != null)
+			return gson.fromJson(attribute, type);
+		else
+			return null;
+	}
+
+	/**
 	 * Reads the attributes map from a given {@link Reader}.
 	 *
 	 * @param reader
@@ -168,9 +190,9 @@ public interface GsonAttributesParser extends N5Reader {
 	 * </ul>
 	 */
 	@Override
-	public default Map<String, Class<?>> listAttributes(String pathName) throws IOException {
+	public default Map<String, Class<?>> listAttributes(final String pathName) throws IOException {
 
-		HashMap<String, JsonElement> jsonElementMap = getAttributes(pathName);
+		final HashMap<String, JsonElement> jsonElementMap = getAttributes(pathName);
 		final HashMap<String, Class<?>> attributes = new HashMap<>();
 		jsonElementMap.forEach(
 				(key, jsonElement) -> {

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSReader.java
@@ -167,7 +167,7 @@ public class N5FSReader extends AbstractGsonReader {
 	public DataBlock<?> readBlock(
 			final String pathName,
 			final DatasetAttributes datasetAttributes,
-			final long[] gridPosition) throws IOException {
+			final long... gridPosition) throws IOException {
 
 		final Path path = Paths.get(basePath, getDataBlockPath(pathName, gridPosition).toString());
 		if (!Files.exists(path))
@@ -206,7 +206,7 @@ public class N5FSReader extends AbstractGsonReader {
 	 */
 	protected static Path getDataBlockPath(
 			final String datasetPathName,
-			final long[] gridPosition) {
+			final long... gridPosition) {
 
 		final String[] pathComponents = new String[gridPosition.length];
 		for (int i = 0; i < pathComponents.length; ++i)

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
@@ -123,15 +123,15 @@ public class N5FSWriter extends N5FSReader implements N5Writer {
 
 	@Override
 	public <T> void writeBlock(
-			final DataBlock<T> dataBlock,
 			final String pathName,
-			final Compression compression) throws IOException {
+			final DatasetAttributes datasetAttributes,
+			final DataBlock<T> dataBlock) throws IOException {
 
 		final Path path = Paths.get(basePath, getDataBlockPath(pathName, dataBlock.getGridPosition()).toString());
 		createDirectories(path.getParent());
 		try (final LockedFileChannel lockedChannel = LockedFileChannel.openForWriting(path)) {
 			lockedChannel.getFileChannel().truncate(0);
-			DefaultBlockWriter.writeBlock(Channels.newOutputStream(lockedChannel.getFileChannel()), dataBlock, compression);
+			DefaultBlockWriter.writeBlock(Channels.newOutputStream(lockedChannel.getFileChannel()), datasetAttributes, dataBlock);
 		}
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5FSWriter.java
@@ -183,7 +183,7 @@ public class N5FSWriter extends N5FSReader implements N5Writer {
 	@Override
 	public boolean deleteBlock(
 			final String pathName,
-			final long[] gridPosition) throws IOException {
+			final long... gridPosition) throws IOException {
 		final Path path = Paths.get(basePath, getDataBlockPath(pathName, gridPosition).toString());
 		if (Files.exists(path))
 			try (final LockedFileChannel channel = LockedFileChannel.openForWriting(path)) {

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
@@ -331,4 +331,29 @@ public interface N5Reader {
 
 		return "/";
 	}
+
+	/**
+	 * Creates a group path by concatenating all nodes with the node separator
+	 * defined by {@link #getGroupSeparator()}.  The string will not have a
+	 * leading or trailing node separator symbol.
+	 *
+	 * @param nodes
+	 * @return
+	 */
+	public default String groupPath(final String... nodes) {
+
+		if (nodes == null || nodes.length == 0)
+			return "";
+
+		final String groupSeparator = getGroupSeparator();
+		final StringBuilder builder = new StringBuilder(nodes[0]);
+
+		for (int i = 1; i < nodes.length; ++i) {
+
+			builder.append(groupSeparator);
+			builder.append(nodes[i]);
+		}
+
+		return builder.toString();
+	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
@@ -29,6 +29,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
+import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -218,6 +219,20 @@ public interface N5Reader {
 			final String pathName,
 			final String key,
 			final Class<T> clazz) throws IOException;
+
+	/**
+	 * Reads an attribute.
+	 *
+	 * @param pathName group path
+	 * @param key
+	 * @param type attribute Type (use this for specifying generic types)
+	 * @return
+	 * @throws IOException
+	 */
+	public <T> T getAttribute(
+			final String pathName,
+			final String key,
+			final Type type) throws IOException;
 
 	/**
 	 * Get mandatory dataset attributes.

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
@@ -321,4 +321,14 @@ public interface N5Reader {
 	 * @throws IOException
 	 */
 	public Map<String, Class<?>> listAttributes(final String pathName) throws IOException;
+
+	/**
+	 * Returns the symbol that is used to separate nodes in a group path.
+	 *
+	 * @return
+	 */
+	public default String getGroupSeparator() {
+
+		return "/";
+	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
@@ -25,7 +25,10 @@
  */
 package org.janelia.saalfeldlab.n5;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -238,6 +241,31 @@ public interface N5Reader {
 			final String pathName,
 			final DatasetAttributes datasetAttributes,
 			final long[] gridPosition) throws IOException;
+
+	/**
+	 * Load a {@link DataBlock} as a {@link Serializable}.  The offset is given
+	 * in {@link DataBlock} grid coordinates.
+	 *
+	 * @param dataset
+	 * @param attributes
+	 * @param gridOffset
+	 * @throws IOException
+	 * @throws ClassNotFoundException
+	 */
+	@SuppressWarnings("unchecked")
+	public default <T> T readSerializedBlock(
+			final String dataset,
+			final DatasetAttributes attributes,
+			final long[] gridOffset) throws IOException, ClassNotFoundException {
+
+
+		final DataBlock<?> block = readBlock(dataset, attributes, gridOffset);
+
+		final ByteArrayInputStream byteArrayInputStream= new ByteArrayInputStream(block.toByteBuffer().array());
+		try (ObjectInputStream in = new ObjectInputStream(byteArrayInputStream)) {
+			return (T)in.readObject();
+		}
+	}
 
 	/**
 	 * Test whether a group or dataset exists.

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
@@ -255,7 +255,7 @@ public interface N5Reader {
 	public DataBlock<?> readBlock(
 			final String pathName,
 			final DatasetAttributes datasetAttributes,
-			final long[] gridPosition) throws IOException;
+			final long... gridPosition) throws IOException;
 
 	/**
 	 * Load a {@link DataBlock} as a {@link Serializable}.  The offset is given
@@ -263,7 +263,7 @@ public interface N5Reader {
 	 *
 	 * @param dataset
 	 * @param attributes
-	 * @param gridOffset
+	 * @param gridPosition
 	 * @throws IOException
 	 * @throws ClassNotFoundException
 	 */
@@ -271,12 +271,14 @@ public interface N5Reader {
 	public default <T> T readSerializedBlock(
 			final String dataset,
 			final DatasetAttributes attributes,
-			final long[] gridOffset) throws IOException, ClassNotFoundException {
+			final long... gridPosition) throws IOException, ClassNotFoundException {
 
 
-		final DataBlock<?> block = readBlock(dataset, attributes, gridOffset);
+		final DataBlock<?> block = readBlock(dataset, attributes, gridPosition);
+		if (block == null)
+			return null;
 
-		final ByteArrayInputStream byteArrayInputStream= new ByteArrayInputStream(block.toByteBuffer().array());
+		final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(block.toByteBuffer().array());
 		try (ObjectInputStream in = new ObjectInputStream(byteArrayInputStream)) {
 			return (T)in.readObject();
 		}

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Writer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Writer.java
@@ -181,7 +181,7 @@ public interface N5Writer extends N5Reader {
 	 */
 	boolean deleteBlock(
 			final String pathName,
-			final long[] gridPosition) throws IOException;
+			final long... gridPosition) throws IOException;
 
 	/**
 	 * Save a {@link Serializable} as an N5 {@link DataBlock} at a given
@@ -190,21 +190,21 @@ public interface N5Writer extends N5Reader {
 	 * @param object
 	 * @param dataset
 	 * @param attributes
-	 * @param gridOffset
+	 * @param gridPosition
 	 * @throws IOException
 	 */
 	public default void writeSerializedBlock(
 			final Serializable object,
 			final String dataset,
 			final DatasetAttributes datasetAttributes,
-			final long[] gridOffset) throws IOException {
+			final long... gridPosition) throws IOException {
 
 		final ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
 		try (ObjectOutputStream out = new ObjectOutputStream(byteOutputStream)) {
 			out.writeObject(object);
 		}
 		final byte[] bytes = byteOutputStream.toByteArray();
-		final DataBlock<?> dataBlock = new ByteArrayDataBlock(null, gridOffset, bytes);
+		final DataBlock<?> dataBlock = new ByteArrayDataBlock(null, gridPosition, bytes);
 		writeBlock(dataset, datasetAttributes, dataBlock);
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Writer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Writer.java
@@ -156,15 +156,16 @@ public interface N5Writer extends N5Reader {
 	/**
 	 * Writes a {@link DataBlock}.
 	 *
-	 * @param dataBlock
 	 * @param pathName dataset path
-	 * @param compression
+	 * @param datasetAttributes
+	 * @param dataBlock
 	 * @throws IOException
 	 */
 	public <T> void writeBlock(
-			final DataBlock<T> dataBlock,
 			final String pathName,
-			final Compression compression) throws IOException;
+			final DatasetAttributes datasetAttributes,
+			final DataBlock<T> dataBlock) throws IOException;
+
 
 	/**
 	 * Deletes the block at {@code gridPosition}
@@ -195,16 +196,15 @@ public interface N5Writer extends N5Reader {
 	public default void writeSerializedBlock(
 			final Serializable object,
 			final String dataset,
-			final Compression compression,
+			final DatasetAttributes datasetAttributes,
 			final long[] gridOffset) throws IOException {
 
-		final int[] blockSize = new int[gridOffset.length];
 		final ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
 		try (ObjectOutputStream out = new ObjectOutputStream(byteOutputStream)) {
 			out.writeObject(object);
 		}
 		final byte[] bytes = byteOutputStream.toByteArray();
-		final DataBlock<?> dataBlock = new ByteArrayDataBlock(blockSize, gridOffset, bytes);
-		writeBlock(dataBlock, dataset, compression);
+		final DataBlock<?> dataBlock = new ByteArrayDataBlock(null, gridOffset, bytes);
+		writeBlock(dataset, datasetAttributes, dataBlock);
 	}
 }

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -33,6 +33,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.gson.reflect.TypeToken;
+
 /**
  * Abstract base class for testing N5 functionality.
  * Subclasses are expected to provide a specific N5 implementation to be tested by defining the {@link #createN5Writer()} method.
@@ -412,24 +414,38 @@ public abstract class AbstractN5Test {
 
 			n5.setAttribute(groupName, "key1", "value1");
 			Assert.assertEquals(1, n5.listAttributes(groupName).size());
+
+			/* class interface */
 			Assert.assertEquals("value1", n5.getAttribute(groupName, "key1", String.class));
+			/* type interface */
+			Assert.assertEquals("value1", n5.getAttribute(groupName, "key1", new TypeToken<String>(){}.getType()));
 
 			final Map<String, String> newAttributes = new HashMap<>();
 			newAttributes.put("key2", "value2");
 			newAttributes.put("key3", "value3");
 			n5.setAttributes(groupName, newAttributes);
 			Assert.assertEquals(3, n5.listAttributes(groupName).size());
+			/* class interface */
 			Assert.assertEquals("value1", n5.getAttribute(groupName, "key1", String.class));
 			Assert.assertEquals("value2", n5.getAttribute(groupName, "key2", String.class));
 			Assert.assertEquals("value3", n5.getAttribute(groupName, "key3", String.class));
+			/* type interface */
+			Assert.assertEquals("value1", n5.getAttribute(groupName, "key1", new TypeToken<String>(){}.getType()));
+			Assert.assertEquals("value2", n5.getAttribute(groupName, "key2", new TypeToken<String>(){}.getType()));
+			Assert.assertEquals("value3", n5.getAttribute(groupName, "key3", new TypeToken<String>(){}.getType()));
 
 			// test the case where the resulting file becomes shorter
 			n5.setAttribute(groupName, "key1", new Integer(1));
 			n5.setAttribute(groupName, "key2", new Integer(2));
 			Assert.assertEquals(3, n5.listAttributes(groupName).size());
+			/* class interface */
 			Assert.assertEquals(new Integer(1), n5.getAttribute(groupName, "key1", Integer.class));
 			Assert.assertEquals(new Integer(2), n5.getAttribute(groupName, "key2", Integer.class));
 			Assert.assertEquals("value3", n5.getAttribute(groupName, "key3", String.class));
+			/* type interface */
+			Assert.assertEquals(new Integer(1), n5.getAttribute(groupName, "key1", new TypeToken<Integer>(){}.getType()));
+			Assert.assertEquals(new Integer(2), n5.getAttribute(groupName, "key2", new TypeToken<Integer>(){}.getType()));
+			Assert.assertEquals("value3", n5.getAttribute(groupName, "key3", new TypeToken<String>(){}.getType()));
 
 		} catch (final IOException e) {
 			fail(e.getMessage());

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -162,7 +163,7 @@ public abstract class AbstractN5Test {
 					n5.createDataset(datasetName, dimensions, blockSize, dataType, compression);
 					final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
 					final ByteArrayDataBlock dataBlock = new ByteArrayDataBlock(blockSize, new long[]{0, 0, 0}, byteBlock);
-					n5.writeBlock(datasetName, attributes, dataBlock);
+					n5.writeBlock(dataBlock, datasetName, attributes.getCompression());
 
 					final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
 
@@ -191,7 +192,7 @@ public abstract class AbstractN5Test {
 					n5.createDataset(datasetName, dimensions, blockSize, dataType, compression);
 					final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
 					final ShortArrayDataBlock dataBlock = new ShortArrayDataBlock(blockSize, new long[]{0, 0, 0}, shortBlock);
-					n5.writeBlock(datasetName, attributes, dataBlock);
+					n5.writeBlock(dataBlock, datasetName, attributes.getCompression());
 
 					final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
 
@@ -220,7 +221,7 @@ public abstract class AbstractN5Test {
 					n5.createDataset(datasetName, dimensions, blockSize, dataType, compression);
 					final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
 					final IntArrayDataBlock dataBlock = new IntArrayDataBlock(blockSize, new long[]{0, 0, 0}, intBlock);
-					n5.writeBlock(datasetName, attributes, dataBlock);
+					n5.writeBlock(dataBlock, datasetName, attributes.getCompression());
 
 					final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
 
@@ -249,7 +250,7 @@ public abstract class AbstractN5Test {
 					n5.createDataset(datasetName, dimensions, blockSize, dataType, compression);
 					final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
 					final LongArrayDataBlock dataBlock = new LongArrayDataBlock(blockSize, new long[]{0, 0, 0}, longBlock);
-					n5.writeBlock(datasetName, attributes, dataBlock);
+					n5.writeBlock(dataBlock, datasetName, attributes.getCompression());
 
 					final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
 
@@ -274,7 +275,7 @@ public abstract class AbstractN5Test {
 				n5.createDataset(datasetName, dimensions, blockSize, DataType.FLOAT32, compression);
 				final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
 				final FloatArrayDataBlock dataBlock = new FloatArrayDataBlock(blockSize, new long[]{0, 0, 0}, floatBlock);
-				n5.writeBlock(datasetName, attributes, dataBlock);
+				n5.writeBlock(dataBlock, datasetName, attributes.getCompression());
 
 				final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
 
@@ -299,7 +300,7 @@ public abstract class AbstractN5Test {
 				n5.createDataset(datasetName, dimensions, blockSize, DataType.FLOAT64, compression);
 				final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
 				final DoubleArrayDataBlock dataBlock = new DoubleArrayDataBlock(blockSize, new long[]{0, 0, 0}, doubleBlock);
-				n5.writeBlock(datasetName, attributes, dataBlock);
+				n5.writeBlock(dataBlock, datasetName, attributes.getCompression());
 
 				final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
 
@@ -322,18 +323,55 @@ public abstract class AbstractN5Test {
 		for (final Compression compression : getCompressions()) {
 			for (final DataType dataType : new DataType[]{
 					DataType.UINT8,
-					DataType.INT8}) {
+					DataType.INT8,
+					DataType.OBJECT}) {
 
 				System.out.println("Testing " + compression.getType() + " " + dataType + " (mode=1)");
 				try {
 					n5.createDataset(datasetName, dimensions, differentBlockSize, dataType, compression);
 					final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
 					final ByteArrayDataBlock dataBlock = new ByteArrayDataBlock(differentBlockSize, new long[]{0, 0, 0}, byteBlock);
-					n5.writeBlock(datasetName, attributes, dataBlock);
+					n5.writeBlock(dataBlock, datasetName, attributes.getCompression());
 
 					final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
 
 					Assert.assertArrayEquals(byteBlock, (byte[])loadedDataBlock.getData());
+
+					Assert.assertTrue(n5.remove(datasetName));
+
+				} catch (final IOException e) {
+					e.printStackTrace();
+					fail("Block cannot be written.");
+				}
+			}
+		}
+	}
+
+	@Test
+	public void testWriteReadSerializableBlock() throws ClassNotFoundException {
+
+		for (final Compression compression : getCompressions()) {
+			for (final DataType dataType : new DataType[]{
+					DataType.UINT8,
+					DataType.INT8,
+					DataType.OBJECT}) {
+
+				System.out.println("Testing " + compression.getType() + " " + dataType + " (mode=1)");
+				try {
+					n5.createDataset(datasetName, dimensions, blockSize, dataType, compression);
+					final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
+
+					final HashMap<String, ArrayList<double[]>> object = new HashMap<>();
+					object.put("one", new ArrayList<>());
+					object.put("two", new ArrayList<>());
+					object.get("one").add(new double[] {1, 2, 3});
+					object.get("two").add(new double[] {4, 5, 6, 7, 8});
+
+					n5.writeSerializedBlock(object, datasetName, attributes.getCompression(), new long[]{0, 0, 0});
+
+					final HashMap<String, ArrayList<double[]>> loadedObject = n5.readSerializedBlock(datasetName, attributes, new long[]{0, 0, 0});
+
+					object.entrySet().stream().forEach(e -> Assert.assertArrayEquals(e.getValue().get(0), loadedObject.get(e.getKey()).get(0), 0.01));
 
 					Assert.assertTrue(n5.remove(datasetName));
 
@@ -353,13 +391,13 @@ public abstract class AbstractN5Test {
 			final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
 
 			final IntArrayDataBlock randomDataBlock = new IntArrayDataBlock(blockSize, new long[]{0, 0, 0}, intBlock);
-			n5.writeBlock(datasetName, attributes, randomDataBlock);
+			n5.writeBlock(randomDataBlock, datasetName, attributes.getCompression());
 			final DataBlock<?> loadedRandomDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
 			Assert.assertArrayEquals(intBlock, (int[])loadedRandomDataBlock.getData());
 
 			// test the case where the resulting file becomes shorter
 			final IntArrayDataBlock emptyDataBlock = new IntArrayDataBlock(blockSize, new long[]{0, 0, 0}, new int[DataBlock.getNumElements(blockSize)]);
-			n5.writeBlock(datasetName, attributes, emptyDataBlock);
+			n5.writeBlock(emptyDataBlock, datasetName, attributes.getCompression());
 			final DataBlock<?> loadedEmptyDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
 			Assert.assertArrayEquals(new int[DataBlock.getNumElements(blockSize)], (int[])loadedEmptyDataBlock.getData());
 
@@ -521,7 +559,7 @@ public abstract class AbstractN5Test {
 		Assert.assertTrue(testDeleteIsBlockDeleted(n5.readBlock(datasetName, attributes, position2)));
 
 		final ByteArrayDataBlock dataBlock = new ByteArrayDataBlock(blockSize, position1, byteBlock);
-		n5.writeBlock(datasetName, attributes, dataBlock);
+		n5.writeBlock(dataBlock, datasetName, attributes.getCompression());
 
 		// block should exist at position1 but not at position2
 		final DataBlock<?> readBlock = n5.readBlock(datasetName, attributes, position1);

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -163,7 +163,7 @@ public abstract class AbstractN5Test {
 					n5.createDataset(datasetName, dimensions, blockSize, dataType, compression);
 					final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
 					final ByteArrayDataBlock dataBlock = new ByteArrayDataBlock(blockSize, new long[]{0, 0, 0}, byteBlock);
-					n5.writeBlock(dataBlock, datasetName, attributes.getCompression());
+					n5.writeBlock(datasetName, attributes, dataBlock);
 
 					final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
 
@@ -192,7 +192,7 @@ public abstract class AbstractN5Test {
 					n5.createDataset(datasetName, dimensions, blockSize, dataType, compression);
 					final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
 					final ShortArrayDataBlock dataBlock = new ShortArrayDataBlock(blockSize, new long[]{0, 0, 0}, shortBlock);
-					n5.writeBlock(dataBlock, datasetName, attributes.getCompression());
+					n5.writeBlock(datasetName, attributes, dataBlock);
 
 					final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
 
@@ -221,7 +221,7 @@ public abstract class AbstractN5Test {
 					n5.createDataset(datasetName, dimensions, blockSize, dataType, compression);
 					final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
 					final IntArrayDataBlock dataBlock = new IntArrayDataBlock(blockSize, new long[]{0, 0, 0}, intBlock);
-					n5.writeBlock(dataBlock, datasetName, attributes.getCompression());
+					n5.writeBlock(datasetName, attributes, dataBlock);
 
 					final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
 
@@ -250,7 +250,7 @@ public abstract class AbstractN5Test {
 					n5.createDataset(datasetName, dimensions, blockSize, dataType, compression);
 					final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
 					final LongArrayDataBlock dataBlock = new LongArrayDataBlock(blockSize, new long[]{0, 0, 0}, longBlock);
-					n5.writeBlock(dataBlock, datasetName, attributes.getCompression());
+					n5.writeBlock(datasetName, attributes, dataBlock);
 
 					final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
 
@@ -275,7 +275,7 @@ public abstract class AbstractN5Test {
 				n5.createDataset(datasetName, dimensions, blockSize, DataType.FLOAT32, compression);
 				final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
 				final FloatArrayDataBlock dataBlock = new FloatArrayDataBlock(blockSize, new long[]{0, 0, 0}, floatBlock);
-				n5.writeBlock(dataBlock, datasetName, attributes.getCompression());
+				n5.writeBlock(datasetName, attributes, dataBlock);
 
 				final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
 
@@ -300,7 +300,7 @@ public abstract class AbstractN5Test {
 				n5.createDataset(datasetName, dimensions, blockSize, DataType.FLOAT64, compression);
 				final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
 				final DoubleArrayDataBlock dataBlock = new DoubleArrayDataBlock(blockSize, new long[]{0, 0, 0}, doubleBlock);
-				n5.writeBlock(dataBlock, datasetName, attributes.getCompression());
+				n5.writeBlock(datasetName, attributes, dataBlock);
 
 				final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
 
@@ -323,15 +323,14 @@ public abstract class AbstractN5Test {
 		for (final Compression compression : getCompressions()) {
 			for (final DataType dataType : new DataType[]{
 					DataType.UINT8,
-					DataType.INT8,
-					DataType.OBJECT}) {
+					DataType.INT8}) {
 
 				System.out.println("Testing " + compression.getType() + " " + dataType + " (mode=1)");
 				try {
 					n5.createDataset(datasetName, dimensions, differentBlockSize, dataType, compression);
 					final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
 					final ByteArrayDataBlock dataBlock = new ByteArrayDataBlock(differentBlockSize, new long[]{0, 0, 0}, byteBlock);
-					n5.writeBlock(dataBlock, datasetName, attributes.getCompression());
+					n5.writeBlock(datasetName, attributes, dataBlock);
 
 					final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
 
@@ -351,34 +350,30 @@ public abstract class AbstractN5Test {
 	public void testWriteReadSerializableBlock() throws ClassNotFoundException {
 
 		for (final Compression compression : getCompressions()) {
-			for (final DataType dataType : new DataType[]{
-					DataType.UINT8,
-					DataType.INT8,
-					DataType.OBJECT}) {
 
-				System.out.println("Testing " + compression.getType() + " " + dataType + " (mode=1)");
-				try {
-					n5.createDataset(datasetName, dimensions, blockSize, dataType, compression);
-					final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
+			final DataType dataType = DataType.OBJECT;
+			System.out.println("Testing " + compression.getType() + " " + dataType + " (mode=2)");
+			try {
+				n5.createDataset(datasetName, dimensions, blockSize, dataType, compression);
+				final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
 
-					final HashMap<String, ArrayList<double[]>> object = new HashMap<>();
-					object.put("one", new ArrayList<>());
-					object.put("two", new ArrayList<>());
-					object.get("one").add(new double[] {1, 2, 3});
-					object.get("two").add(new double[] {4, 5, 6, 7, 8});
+				final HashMap<String, ArrayList<double[]>> object = new HashMap<>();
+				object.put("one", new ArrayList<>());
+				object.put("two", new ArrayList<>());
+				object.get("one").add(new double[] {1, 2, 3});
+				object.get("two").add(new double[] {4, 5, 6, 7, 8});
 
-					n5.writeSerializedBlock(object, datasetName, attributes.getCompression(), new long[]{0, 0, 0});
+				n5.writeSerializedBlock(object, datasetName, attributes, new long[]{0, 0, 0});
 
-					final HashMap<String, ArrayList<double[]>> loadedObject = n5.readSerializedBlock(datasetName, attributes, new long[]{0, 0, 0});
+				final HashMap<String, ArrayList<double[]>> loadedObject = n5.readSerializedBlock(datasetName, attributes, new long[]{0, 0, 0});
 
-					object.entrySet().stream().forEach(e -> Assert.assertArrayEquals(e.getValue().get(0), loadedObject.get(e.getKey()).get(0), 0.01));
+				object.entrySet().stream().forEach(e -> Assert.assertArrayEquals(e.getValue().get(0), loadedObject.get(e.getKey()).get(0), 0.01));
 
-					Assert.assertTrue(n5.remove(datasetName));
+				Assert.assertTrue(n5.remove(datasetName));
 
-				} catch (final IOException e) {
-					e.printStackTrace();
-					fail("Block cannot be written.");
-				}
+			} catch (final IOException e) {
+				e.printStackTrace();
+				fail("Block cannot be written.");
 			}
 		}
 	}
@@ -391,13 +386,13 @@ public abstract class AbstractN5Test {
 			final DatasetAttributes attributes = n5.getDatasetAttributes(datasetName);
 
 			final IntArrayDataBlock randomDataBlock = new IntArrayDataBlock(blockSize, new long[]{0, 0, 0}, intBlock);
-			n5.writeBlock(randomDataBlock, datasetName, attributes.getCompression());
+			n5.writeBlock(datasetName, attributes, randomDataBlock);
 			final DataBlock<?> loadedRandomDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
 			Assert.assertArrayEquals(intBlock, (int[])loadedRandomDataBlock.getData());
 
 			// test the case where the resulting file becomes shorter
 			final IntArrayDataBlock emptyDataBlock = new IntArrayDataBlock(blockSize, new long[]{0, 0, 0}, new int[DataBlock.getNumElements(blockSize)]);
-			n5.writeBlock(emptyDataBlock, datasetName, attributes.getCompression());
+			n5.writeBlock(datasetName, attributes, emptyDataBlock);
 			final DataBlock<?> loadedEmptyDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
 			Assert.assertArrayEquals(new int[DataBlock.getNumElements(blockSize)], (int[])loadedEmptyDataBlock.getData());
 
@@ -559,7 +554,7 @@ public abstract class AbstractN5Test {
 		Assert.assertTrue(testDeleteIsBlockDeleted(n5.readBlock(datasetName, attributes, position2)));
 
 		final ByteArrayDataBlock dataBlock = new ByteArrayDataBlock(blockSize, position1, byteBlock);
-		n5.writeBlock(dataBlock, datasetName, attributes.getCompression());
+		n5.writeBlock(datasetName, attributes, dataBlock);
 
 		// block should exist at position1 but not at position2
 		final DataBlock<?> readBlock = n5.readBlock(datasetName, attributes, position1);

--- a/src/test/java/org/janelia/saalfeldlab/n5/N5Benchmark.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/N5Benchmark.java
@@ -83,7 +83,6 @@ public class N5Benchmark {
 
 		data = new short[64 * 64 * 64];
 		final ImagePlus imp = new Opener().openURL("https://imagej.nih.gov/ij/images/t1-head-raw.zip");
-		@SuppressWarnings("unchecked")
 		final ImagePlusImg<UnsignedShortType, ?> img = (ImagePlusImg<UnsignedShortType, ?>)(Object)ImagePlusImgs.from(imp);
 		final Cursor<UnsignedShortType> cursor = Views.flatIterable(Views.interval(img, new long[]{100, 100, 30}, new long[]{163, 163, 93})).cursor();
 		for (int i = 0; i < data.length; ++i)
@@ -120,7 +119,7 @@ public class N5Benchmark {
 				n5.createDataset(compressedDatasetName, new long[]{1, 2, 3}, new int[]{1, 2, 3}, DataType.UINT16, compression);
 				final DatasetAttributes attributes = n5.getDatasetAttributes(compressedDatasetName);
 				final ShortArrayDataBlock dataBlock = new ShortArrayDataBlock(new int[]{1, 2, 3}, new long[]{0, 0, 0}, dataBlockData);
-				n5.writeBlock(dataBlock, compressedDatasetName, attributes.getCompression());
+				n5.writeBlock(compressedDatasetName, attributes, dataBlock);
 			} catch (final IOException e) {
 				fail(e.getMessage());
 			}
@@ -144,7 +143,7 @@ public class N5Benchmark {
 						for (int y = 0; y < nBlocks; ++y)
 							for (int x = 0; x < nBlocks; ++x) {
 								final ShortArrayDataBlock dataBlock = new ShortArrayDataBlock(new int[]{64, 64, 64}, new long[]{x, y, z}, data);
-								n5.writeBlock(dataBlock, compressedDatasetName, attributes.getCompression());
+								n5.writeBlock(compressedDatasetName, attributes, dataBlock);
 							}
 				} catch (final IOException e) {
 					fail(e.getMessage());
@@ -233,7 +232,7 @@ public class N5Benchmark {
 										exec.submit(
 												() -> {
 													final ShortArrayDataBlock dataBlock = new ShortArrayDataBlock(new int[]{64, 64, 64}, new long[]{fx, fy, fz}, data);
-													n5.writeBlock(dataBlock, compressedDatasetName, attributes.getCompression());
+													n5.writeBlock(compressedDatasetName, attributes, dataBlock);
 													return true;
 												}));
 							}

--- a/src/test/java/org/janelia/saalfeldlab/n5/N5Benchmark.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/N5Benchmark.java
@@ -83,6 +83,7 @@ public class N5Benchmark {
 
 		data = new short[64 * 64 * 64];
 		final ImagePlus imp = new Opener().openURL("https://imagej.nih.gov/ij/images/t1-head-raw.zip");
+		@SuppressWarnings("unchecked")
 		final ImagePlusImg<UnsignedShortType, ?> img = (ImagePlusImg<UnsignedShortType, ?>)(Object)ImagePlusImgs.from(imp);
 		final Cursor<UnsignedShortType> cursor = Views.flatIterable(Views.interval(img, new long[]{100, 100, 30}, new long[]{163, 163, 93})).cursor();
 		for (int i = 0; i < data.length; ++i)
@@ -119,7 +120,7 @@ public class N5Benchmark {
 				n5.createDataset(compressedDatasetName, new long[]{1, 2, 3}, new int[]{1, 2, 3}, DataType.UINT16, compression);
 				final DatasetAttributes attributes = n5.getDatasetAttributes(compressedDatasetName);
 				final ShortArrayDataBlock dataBlock = new ShortArrayDataBlock(new int[]{1, 2, 3}, new long[]{0, 0, 0}, dataBlockData);
-				n5.writeBlock(compressedDatasetName, attributes, dataBlock);
+				n5.writeBlock(dataBlock, compressedDatasetName, attributes.getCompression());
 			} catch (final IOException e) {
 				fail(e.getMessage());
 			}
@@ -143,7 +144,7 @@ public class N5Benchmark {
 						for (int y = 0; y < nBlocks; ++y)
 							for (int x = 0; x < nBlocks; ++x) {
 								final ShortArrayDataBlock dataBlock = new ShortArrayDataBlock(new int[]{64, 64, 64}, new long[]{x, y, z}, data);
-								n5.writeBlock(compressedDatasetName, attributes, dataBlock);
+								n5.writeBlock(dataBlock, compressedDatasetName, attributes.getCompression());
 							}
 				} catch (final IOException e) {
 					fail(e.getMessage());
@@ -232,7 +233,7 @@ public class N5Benchmark {
 										exec.submit(
 												() -> {
 													final ShortArrayDataBlock dataBlock = new ShortArrayDataBlock(new int[]{64, 64, 64}, new long[]{fx, fy, fz}, data);
-													n5.writeBlock(compressedDatasetName, attributes, dataBlock);
+													n5.writeBlock(dataBlock, compressedDatasetName, attributes.getCompression());
 													return true;
 												}));
 							}


### PR DESCRIPTION
* introduces DataType.OBJECT that maps to bytes
* introduces block mode 2 because serialized objects do not have a blocksize or
  number of dimensions