### PR TITLE
add default deepList to N5Reader

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
@@ -37,9 +37,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -557,14 +555,4 @@ public interface N5Reader extends AutoCloseable {
 	 */
 	@Override
 	public default void close() {}
-
-	public static <T> void async(
-			final Supplier<T> request,
-			final Consumer<T> callback,
-			final ExecutorService exec) {
-
-		exec.submit(() -> {
-			callback.accept(request.get());
-		});
-	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
@@ -382,6 +382,17 @@ public interface N5Reader extends AutoCloseable {
 	 * children of paths that were excluded may be included (filter does not
 	 * apply to the subtree).
 	 *
+	 * <p>This method delivers the same results as</p>
+	 * <pre>n5.deepList(
+	 *   prefix,
+	 *   a -> {
+	 *     try { return n5.datasetExists(a) && filter.test(a); }
+	 *     catch (final IOException e) { return false; }
+	 *   });</pre>
+	 * <p>but will execute {@link #datasetExists(String)} only once per node.
+	 * This can be relevant for performance on high latency backends such as
+	 * cloud stores.</p>
+	 *
 	 * @param pathName
 	 *            base group path
 	 * @param filter
@@ -407,6 +418,17 @@ public interface N5Reader extends AutoCloseable {
 
 	/**
 	 * Recursively list all including datasets in the given group.
+	 *
+	 * <p>This method delivers the same results as</p>
+	 * <pre>n5.deepList(
+	 *   prefix,
+	 *   a -> {
+	 *     try { return n5.datasetExists(a); }
+	 *     catch (final IOException e) { return false; }
+	 *   });</pre>
+	 * <p>but will execute {@link #datasetExists(String)} only once per node.
+	 * This can be relevant for performance on high latency backends such as
+	 * cloud stores.</p>
 	 *
 	 * @param pathName
 	 *            base group path
@@ -513,6 +535,18 @@ public interface N5Reader extends AutoCloseable {
 	 * that were excluded may be included (filter does not apply to the
 	 * subtree).
 	 *
+	 * <p>This method delivers the same results as</p>
+	 * <pre>n5.deepList(
+	 *   prefix,
+	 *   a -> {
+	 *     try { return n5.datasetExists(a) && filter.test(a); }
+	 *     catch (final IOException e) { return false; }
+	 *   },
+	 *   exec);</pre>
+	 * <p>but will execute {@link #datasetExists(String)} only once per node.
+	 * This can be relevant for performance on high latency backends such as
+	 * cloud stores.</p>
+	 *
 	 * @param pathName
 	 *            base group path
 	 * @param filter
@@ -548,6 +582,18 @@ public interface N5Reader extends AutoCloseable {
 	/**
 	 * Recursively list all datasets in the given group, in
 	 * parallel, using the given {@link ExecutorService}.
+	 *
+	 * <p>This method delivers the same results as</p>
+	 * <pre>n5.deepList(
+	 *   prefix,
+	 *   a -> {
+	 *     try { return n5.datasetExists(a); }
+	 *     catch (final IOException e) { return false; }
+	 *   },
+	 *   exec);</pre>
+	 * <p>but will execute {@link #datasetExists(String)} only once per node.
+	 * This can be relevant for performance on high latency backends such as
+	 * cloud stores.</p>
 	 *
 	 * @param pathName
 	 *            base group path

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
@@ -373,8 +373,14 @@ public interface N5Reader extends AutoCloseable {
 	 * @throws ExecutionException 
 	 * @throws InterruptedException 
 	 */
-	public default List<String> deepListParallel(final String pathName, final ExecutorService executor ) throws IOException, InterruptedException, ExecutionException
+	public default List<String> deepListParallel(final String pathNameIn, final ExecutorService executor ) throws IOException, InterruptedException, ExecutionException
 	{
+		final String pathName;
+		if( pathNameIn.isEmpty() )
+			pathName = "/";
+		else
+			pathName = pathNameIn;
+
 		List< String > results = Collections.synchronizedList( new ArrayList< String >() );
 		LinkedBlockingQueue< Future< String >> datasetFutures = new LinkedBlockingQueue<>();
 		deepListParallelHelper( this, pathName, executor, datasetFutures );
@@ -384,9 +390,6 @@ public interface N5Reader extends AutoCloseable {
 			String s = datasetFutures.poll().get();
 			if( !s.isEmpty())
 				results.add( s );
-
-			// TODO not so happy with this
-			Thread.sleep( 500 );
 		}
 		return results;
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
@@ -394,10 +394,12 @@ public interface N5Reader extends AutoCloseable {
 
 		if (filter.test(pathName)) children.add(pathName);
 
-		final String groupSeparator = n5.getGroupSeparator();
-		final String[] baseChildren = n5.list(pathName);
-		for (final String child : baseChildren)
-			children.addAll(deepList(n5, pathName + groupSeparator + child, filter));
+		if (!n5.datasetExists(pathName)) {
+			final String groupSeparator = n5.getGroupSeparator();
+			final String[] baseChildren = n5.list(pathName);
+			for (final String child : baseChildren)
+				children.addAll(deepList(n5, pathName + groupSeparator + child, filter));
+		}
 
 		return children;
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
@@ -328,20 +328,17 @@ public interface N5Reader extends AutoCloseable {
 	 * @return list of datasets
 	 * @throws IOException 
 	 */
-	public default List<String> deepList(final String pathNameIn) throws IOException
+	public default List<String> deepList( final String pathName ) throws IOException
 	{
 		ArrayList< String > children = new ArrayList<>();
 		ArrayList< String > datasets = new ArrayList<>();
 
-		final String pathName;
-		if( pathNameIn.endsWith( "/" ))
-			pathName = pathNameIn.substring( 0, pathNameIn.length() - 1 );
-		else
-			pathName = pathNameIn;
-
 		final String[] baseChildren  = list( pathName );
 		for( final String child : baseChildren )
-			children.add( pathName + child );
+			if( pathName.endsWith( "/" ))
+				children.add( pathName + child );
+			else
+				children.add( pathName + "/" + child );
 
 		while( !children.isEmpty() )
 		{
@@ -373,14 +370,8 @@ public interface N5Reader extends AutoCloseable {
 	 * @throws ExecutionException 
 	 * @throws InterruptedException 
 	 */
-	public default List<String> deepListParallel(final String pathNameIn, final ExecutorService executor ) throws IOException, InterruptedException, ExecutionException
+	public default List<String> deepListParallel(final String pathName, final ExecutorService executor ) throws IOException, InterruptedException, ExecutionException
 	{
-		final String pathName;
-		if( pathNameIn.endsWith( "/" ))
-			pathName = pathNameIn.substring( 0, pathNameIn.length() - 1 );
-		else
-			pathName = pathNameIn;
-
 		List< String > results = Collections.synchronizedList( new ArrayList< String >() );
 		LinkedBlockingQueue< Future< String >> datasetFutures = new LinkedBlockingQueue<>();
 		deepListParallelHelper( this, pathName, executor, datasetFutures );
@@ -429,7 +420,13 @@ public interface N5Reader extends AutoCloseable {
 					{
 						for( final String child : children )
 						{
-							deepListParallelHelper( n5, path + "/" + child, executor, datasetFutures );
+							final String fullChildPath;
+							if( path.endsWith( "/" ))
+								fullChildPath = path + child;
+							else
+								fullChildPath = path + "/" + child;
+
+							deepListParallelHelper( n5, fullChildPath, executor, datasetFutures );
 						}
 					}
 				}

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -108,15 +107,13 @@ public interface N5Reader extends AutoCloseable {
 					else
 						patch = 0;
 					suffix = matcher.group(6);
-				}
-				else {
+				} else {
 					major = 0;
 					minor = 0;
 					patch = 0;
 					suffix = "";
 				}
-			}
-			else {
+			} else {
 				major = 0;
 				minor = 0;
 				patch = 0;
@@ -163,20 +160,20 @@ public interface N5Reader extends AutoCloseable {
 
 			if (other instanceof Version) {
 				final Version otherVersion = (Version)other;
-				return
-						(major == otherVersion.major) &
+				return (major == otherVersion.major) &
 						(minor == otherVersion.minor) &
 						(patch == otherVersion.patch) &
 						(suffix.equals(otherVersion.suffix));
-			}
-			else
+			} else
 				return false;
 		}
 
 		/**
-		 * Returns true if this implementation is compatible with a given version.
+		 * Returns true if this implementation is compatible with a given
+		 * version.
 		 *
-		 * Currently, this means that the version is less than or equal to 1.X.X.
+		 * Currently, this means that the version is less than or equal to
+		 * 1.X.X.
 		 *
 		 * @param version
 		 * @return
@@ -190,7 +187,8 @@ public interface N5Reader extends AutoCloseable {
 	/**
 	 * SemVer version of this N5 spec.
 	 */
-	public static final Version VERSION = new Version(VersionUtils.getVersionFromPOM(N5Reader.class, "org.janelia.saalfeldlab", "n5"));
+	public static final Version VERSION = new Version(
+			VersionUtils.getVersionFromPOM(N5Reader.class, "org.janelia.saalfeldlab", "n5"));
 
 	/**
 	 * Version attribute key.
@@ -202,7 +200,7 @@ public interface N5Reader extends AutoCloseable {
 	 * attribute of the root group.
 	 *
 	 * If no version is specified or the version string does not conform to
-	 * the SemVer format, 0.0.0 will be returned.  For incomplete versions,
+	 * the SemVer format, 0.0.0 will be returned. For incomplete versions,
 	 * such as 1.2, the missing elements are filled with 0, i.e. 1.2.0 in this
 	 * case.
 	 *
@@ -217,9 +215,11 @@ public interface N5Reader extends AutoCloseable {
 	/**
 	 * Reads an attribute.
 	 *
-	 * @param pathName group path
+	 * @param pathName
+	 *            group path
 	 * @param key
-	 * @param clazz attribute class
+	 * @param clazz
+	 *            attribute class
 	 * @return
 	 * @throws IOException
 	 */
@@ -231,9 +231,11 @@ public interface N5Reader extends AutoCloseable {
 	/**
 	 * Reads an attribute.
 	 *
-	 * @param pathName group path
+	 * @param pathName
+	 *            group path
 	 * @param key
-	 * @param type attribute Type (use this for specifying generic types)
+	 * @param type
+	 *            attribute Type (use this for specifying generic types)
 	 * @return
 	 * @throws IOException
 	 */
@@ -245,8 +247,10 @@ public interface N5Reader extends AutoCloseable {
 	/**
 	 * Get mandatory dataset attributes.
 	 *
-	 * @param pathName dataset path
-	 * @return dataset attributes or null if either dimensions or dataType are not set
+	 * @param pathName
+	 *            dataset path
+	 * @return dataset attributes or null if either dimensions or dataType are
+	 *         not set
 	 * @throws IOException
 	 */
 	public DatasetAttributes getDatasetAttributes(final String pathName) throws IOException;
@@ -254,7 +258,8 @@ public interface N5Reader extends AutoCloseable {
 	/**
 	 * Reads a {@link DataBlock}.
 	 *
-	 * @param pathName dataset path
+	 * @param pathName
+	 *            dataset path
 	 * @param datasetAttributes
 	 * @param gridPosition
 	 * @return
@@ -266,7 +271,7 @@ public interface N5Reader extends AutoCloseable {
 			final long... gridPosition) throws IOException;
 
 	/**
-	 * Load a {@link DataBlock} as a {@link Serializable}.  The offset is given
+	 * Load a {@link DataBlock} as a {@link Serializable}. The offset is given
 	 * in {@link DataBlock} grid coordinates.
 	 *
 	 * @param dataset
@@ -281,7 +286,6 @@ public interface N5Reader extends AutoCloseable {
 			final DatasetAttributes attributes,
 			final long... gridPosition) throws IOException, ClassNotFoundException {
 
-
 		final DataBlock<?> block = readBlock(dataset, attributes, gridPosition);
 		if (block == null)
 			return null;
@@ -295,7 +299,8 @@ public interface N5Reader extends AutoCloseable {
 	/**
 	 * Test whether a group or dataset exists.
 	 *
-	 * @param pathName group path
+	 * @param pathName
+	 *            group path
 	 * @return
 	 */
 	public boolean exists(final String pathName);
@@ -303,7 +308,8 @@ public interface N5Reader extends AutoCloseable {
 	/**
 	 * Test whether a dataset exists.
 	 *
-	 * @param pathName dataset path
+	 * @param pathName
+	 *            dataset path
 	 * @return
 	 * @throws IOException
 	 */
@@ -315,130 +321,130 @@ public interface N5Reader extends AutoCloseable {
 	/**
 	 * List all groups (including datasets) in a group.
 	 *
-	 * @param pathName group path
+	 * @param pathName
+	 *            group path
 	 * @return
 	 * @throws IOException
 	 */
 	public String[] list(final String pathName) throws IOException;
 
+
 	/**
-	 * Lists all datasets in the given group and children of this group.
-	 * 
-	 * @param pathNameIn base group path
-	 * @return list of datasets
-	 * @throws IOException 
+	 * Recursively list all groups (including datasets) in the given group.
+	 *
+	 * @param pathName
+	 *            base group path
+	 * @return list of groups
+	 * @throws IOException
 	 */
-	public default List<String> deepList( final String pathName ) throws IOException
-	{
-		ArrayList< String > children = new ArrayList<>();
-		ArrayList< String > datasets = new ArrayList<>();
+	public default String[] deepList(final String pathName) throws IOException {
 
-		final String[] baseChildren  = list( pathName );
-		for( final String child : baseChildren )
-			if( pathName.endsWith( "/" ))
-				children.add( pathName + child );
-			else
-				children.add( pathName + "/" + child );
+		final String normalPathName = pathName.replaceAll("(^/*)|(/*$)", "");
 
-		while( !children.isEmpty() )
-		{
-			String elem = children.remove( 0 );
-			if( datasetExists( elem ))
-			{
-				datasets.add( elem );
-			}
-			else
-			{
-				final String[] lsResult = list( elem );
-				for( final String child : lsResult )
-				{
-					children.add( elem + "/" + child );
-				}
-			}
-		}
-		return datasets;
+		final List<String> absolutePaths = deepList(this, normalPathName);
+		return absolutePaths.stream().map(a -> a.replaceFirst(normalPathName + "/", "")).toArray(String[]::new);
 	}
 
 	/**
-	 * Lists all datasets in the given group and children of this group, in parallel,
+	 * Helper method to recursively list all groups.
+	 *
+	 * TODO make private when committing to Java versions >8
+	 */
+	static ArrayList<String> deepList(
+			final N5Reader n5,
+			final String pathName) throws IOException {
+
+		final ArrayList<String> children = new ArrayList<>();
+
+		if (!pathName.isEmpty())
+			children.add(pathName);
+
+		final String[] baseChildren = n5.list(pathName);
+		for (final String child : baseChildren)
+			children.addAll(deepList(n5, pathName + "/" + child));
+
+		return children;
+	}
+
+	/**
+	 * Lists all datasets in the given group and children of this group, in
+	 * parallel,
 	 * using the given {@link ExecutorService}.
-	 * 
-	 * @param pathName base group path
-	 * @param executor executor service
+	 *
+	 * @param pathName
+	 *            base group path
+	 * @param executor
+	 *            executor service
 	 * @return list of datasets
-	 * @throws IOException 
-	 * @throws ExecutionException 
-	 * @throws InterruptedException 
+	 * @throws IOException
+	 * @throws ExecutionException
+	 * @throws InterruptedException
 	 */
-	public default List<String> deepListParallel(final String pathName, final ExecutorService executor ) throws IOException, InterruptedException, ExecutionException
-	{
-		List< String > results = Collections.synchronizedList( new ArrayList< String >() );
-		LinkedBlockingQueue< Future< String >> datasetFutures = new LinkedBlockingQueue<>();
-		deepListParallelHelper( this, pathName, executor, datasetFutures );
+	public default String[] deepListParallel(
+			final String pathName,
+			final ExecutorService executor) throws IOException, InterruptedException, ExecutionException {
 
-		while( !datasetFutures.isEmpty() )
-		{
-			String s = datasetFutures.poll().get();
-			if( !s.isEmpty())
-				results.add( s );
-		}
-		return results;
+		final String normalPathName = pathName.replaceAll("(^/*)|(/*$)", "");
+		final List<String> results = Collections.synchronizedList(new ArrayList<String>());
+		final LinkedBlockingQueue<Future<String>> datasetFutures = new LinkedBlockingQueue<>();
+		deepListParallelHelper(this, normalPathName, executor, datasetFutures);
+
+		datasetFutures.poll().get(); // skip self
+		while (!datasetFutures.isEmpty())
+			results.add(datasetFutures.poll().get().substring(normalPathName.length() + 1));
+
+		return results.stream().toArray(String[]::new);
 	}
 
+	/**
+	 * Helper method for parallel deep listing.  This method is not part of the
+	 * public API and is accessible only because Java 8 does not support
+	 * private interface methods yet.
+	 *
+	 * TODO make private when committing to Java versions >8
+	 *
+	 * @param n5
+	 * @param path
+	 * @param executor
+	 * @param datasetFutures
+	 */
 	static void deepListParallelHelper(
 			final N5Reader n5,
 			final String path,
 			final ExecutorService executor,
-			LinkedBlockingQueue< Future< String >> datasetFutures )
-	{
-		datasetFutures.add( executor.submit( new Callable<String>()
-		{
-			@Override
-			public String call()
-			{
-				boolean isDataset = false;
-				try
-				{
-					isDataset = n5.datasetExists( path );
-				}
-				catch ( IOException e ) { }
+			final LinkedBlockingQueue<Future<String>> datasetFutures) {
 
-				if ( isDataset )
-				{
-					return path;
-				}
-				else
-				{
-					String[] children = null;
-					try
-					{
-						children = n5.list( path );
+		datasetFutures.add(executor.submit(() -> {
+
+			boolean isDataset = false;
+			try {
+				isDataset = n5.datasetExists(path);
+			} catch (final IOException e) {}
+
+			if (!isDataset) {
+				String[] children = null;
+				try {
+					children = n5.list(path);
+					for (final String child : children) {
+						final String fullChildPath;
+						if (path.endsWith("/"))
+							fullChildPath = path + child;
+						else
+							fullChildPath = path + "/" + child;
+
+						deepListParallelHelper(n5, fullChildPath, executor, datasetFutures);
 					}
-					catch ( IOException e ) { }
-
-					if( children != null )
-					{
-						for( final String child : children )
-						{
-							final String fullChildPath;
-							if( path.endsWith( "/" ))
-								fullChildPath = path + child;
-							else
-								fullChildPath = path + "/" + child;
-
-							deepListParallelHelper( n5, fullChildPath, executor, datasetFutures );
-						}
-					}
-				}
-				return "";
+				} catch (final IOException e) {}
 			}
+			return path;
 		}));
 	}
 
 	/**
 	 * List all attributes and their class of a group.
 	 *
-	 * @param pathName group path
+	 * @param pathName
+	 *            group path
 	 * @return
 	 * @throws IOException
 	 */
@@ -456,7 +462,7 @@ public interface N5Reader extends AutoCloseable {
 
 	/**
 	 * Creates a group path by concatenating all nodes with the node separator
-	 * defined by {@link #getGroupSeparator()}.  The string will not have a
+	 * defined by {@link #getGroupSeparator()}. The string will not have a
 	 * leading or trailing node separator symbol.
 	 *
 	 * @param nodes

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
@@ -385,7 +385,7 @@ public interface N5Reader extends AutoCloseable {
 		return results;
 	}
 
-	public static void deepListParallelHelper( 
+	static void deepListParallelHelper(
 			final N5Reader n5,
 			final String path,
 			final ExecutorService executor,

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
@@ -334,8 +334,8 @@ public interface N5Reader extends AutoCloseable {
 		ArrayList< String > datasets = new ArrayList<>();
 
 		final String pathName;
-		if( pathNameIn.isEmpty() )
-			pathName = "/";
+		if( pathNameIn.endsWith( "/" ))
+			pathName = pathNameIn.substring( 0, pathNameIn.length() - 1 );
 		else
 			pathName = pathNameIn;
 
@@ -376,8 +376,8 @@ public interface N5Reader extends AutoCloseable {
 	public default List<String> deepListParallel(final String pathNameIn, final ExecutorService executor ) throws IOException, InterruptedException, ExecutionException
 	{
 		final String pathName;
-		if( pathNameIn.isEmpty() )
-			pathName = "/";
+		if( pathNameIn.endsWith( "/" ))
+			pathName = pathNameIn.substring( 0, pathNameIn.length() - 1 );
 		else
 			pathName = pathNameIn;
 

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -526,7 +526,7 @@ public abstract class AbstractN5Test {
 			Assert.assertFalse("deepList stops at datasets", datasetList2.contains(datasetName + "/0"));
 
 			final String prefix = "/test";
-			final String suffix = "/group/dataset";
+			final String datasetSuffix = "group/dataset";
 			final List<String> datasetList3 = Arrays.asList(n5.deepList(prefix));
 			for (final String subGroup : subGroupNames)
 				Assert.assertTrue("deepList contents", datasetList3.contains("group/" + subGroup));
@@ -570,6 +570,21 @@ public abstract class AbstractN5Test {
 			final List<String> datasetListFilterP2 = Arrays.asList( n5.deepList(prefix, isBorC, Executors.newFixedThreadPool(2)));
 			Assert.assertTrue("deepList filter \"b or c\"", 
 				datasetListFilterP2.stream().map( x -> prefix + x).allMatch(isBorC));
+
+			// test dataset filtering
+			final List<String> datasetListFilterD = Arrays.asList( n5.deepListDatasets(prefix));
+			Assert.assertTrue("deepListDataset", datasetListFilterD.size()==1 &&
+					(prefix+"/"+datasetListFilterD.get(0)).equals(datasetName));
+
+			final List<String> datasetListFilterDandBC = Arrays.asList( n5.deepListDatasets(prefix, isBorC));
+			Assert.assertTrue("deepListDatasetFilter", datasetListFilterDandBC.size()==0 );
+
+			final List<String> datasetListFilterDP = Arrays.asList( n5.deepListDatasets(prefix, Executors.newFixedThreadPool(2)));
+			Assert.assertTrue("deepListDataset Parallel", datasetListFilterDP.size()==1 &&
+					(prefix+"/"+datasetListFilterDP.get(0)).equals(datasetName));
+
+			final List<String> datasetListFilterDandBCP = Arrays.asList( n5.deepListDatasets(prefix, isBorC, Executors.newFixedThreadPool(2)));
+			Assert.assertTrue("deepListDatasetFilter Parallel", datasetListFilterDandBCP.size()==0 );
 
 		} catch (final IOException | InterruptedException | ExecutionException e) {
 			fail(e.getMessage());

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -501,7 +501,6 @@ public abstract class AbstractN5Test {
 				n5.createGroup(groupName + "/" + subGroup);
 
 			final List<String> groupsList = Arrays.asList(n5.deepList("/"));
-			System.out.println(Arrays.toString(groupsList.toArray()));
 			for (final String subGroup : subGroupNames)
 				Assert.assertTrue("deepList contents", groupsList.contains(groupName.replaceFirst("/", "") + "/" + subGroup));
 
@@ -514,7 +513,6 @@ public abstract class AbstractN5Test {
 			for (final String subGroup : subGroupNames)
 				Assert.assertTrue("deepList contents", datasetList.contains(groupName.replaceFirst("/", "") + "/" + subGroup));
 			Assert.assertTrue("deepList contents", datasetList.contains(datasetName.replaceFirst("/", "")));
-
 
 			final List<String> datasetList2 = Arrays.asList(n5.deepList(""));
 			for (final String subGroup : subGroupNames)
@@ -540,6 +538,7 @@ public abstract class AbstractN5Test {
 			Assert.assertTrue("deepList contents", datasetListP2.contains(datasetName.replaceFirst("/", "")));
 
 			final List<String> datasetListP3 = Arrays.asList(n5.deepList(prefix, Executors.newFixedThreadPool(2)));
+			System.out.println(Arrays.toString(datasetListP2.toArray()));
 			for (final String subGroup : subGroupNames)
 				Assert.assertTrue("deepList contents", datasetListP3.contains("group/" + subGroup));
 			Assert.assertTrue("deepList contents", datasetListP3.contains(datasetName.replaceFirst(prefix + "/", "")));

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -496,8 +496,11 @@ public abstract class AbstractN5Test {
 
 	@Test
 	public void testDeepList() {
-
 		try {
+
+			// clear container to start
+			n5.remove();
+
 			n5.createGroup(groupName);
 			for (final String subGroup : subGroupNames)
 				n5.createGroup(groupName + "/" + subGroup);

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -496,44 +496,53 @@ public abstract class AbstractN5Test {
 	public void testDeepList() {
 
 		try {
-			n5.remove(groupName);
-			Assert.assertTrue( "deepList empty", n5.deepList("/").isEmpty() );
-
 			n5.createGroup(groupName);
 			for (final String subGroup : subGroupNames)
 				n5.createGroup(groupName + "/" + subGroup);
 
-			Assert.assertTrue( "deepList empty groups no datasets", n5.deepList("/").isEmpty() );
+			final List<String> groupsList = Arrays.asList(n5.deepList("/"));
+			System.out.println(Arrays.toString(groupsList.toArray()));
+			for (final String subGroup : subGroupNames)
+				Assert.assertTrue("deepList contents", groupsList.contains(groupName.replaceFirst("/", "") + "/" + subGroup));
+
+			for (final String subGroup : subGroupNames)
+				Assert.assertTrue("deepList contents", Arrays.asList(n5.deepList("")).contains(groupName.replaceFirst("/", "") + "/" + subGroup));
 
 			n5.createDataset(datasetName, dimensions, blockSize, DataType.UINT64, new RawCompression());
 
-			final List< String > datasetList = n5.deepList( "/" );
-			Assert.assertEquals( "deepList size", 1, datasetList.size());
-			Assert.assertEquals( "deepList contents", datasetName, datasetList.get(0));
+			final List<String> datasetList = Arrays.asList(n5.deepList("/"));
+			for (final String subGroup : subGroupNames)
+				Assert.assertTrue("deepList contents", datasetList.contains(groupName.replaceFirst("/", "") + "/" + subGroup));
+			Assert.assertTrue("deepList contents", datasetList.contains(datasetName.replaceFirst("/", "")));
 
-			final List< String > datasetList2 = n5.deepList( "" );
-			Assert.assertEquals( "deepList 2 size", 1, datasetList2.size());
-			Assert.assertEquals( "deepList 2 contents", datasetName, datasetList2.get(0));
+
+			final List<String> datasetList2 = Arrays.asList(n5.deepList(""));
+			for (final String subGroup : subGroupNames)
+				Assert.assertTrue("deepList contents", datasetList2.contains(groupName.replaceFirst("/", "") + "/" + subGroup));
+			Assert.assertTrue("deepList contents", datasetList2.contains(datasetName.replaceFirst("/", "")));
 
 			final String prefix = "/test";
 			final String suffix = "/group/dataset";
-			final List< String > datasetList3 = n5.deepList( prefix );
-			Assert.assertEquals( "deepList 3 size", 1, datasetList3.size() );
-			Assert.assertEquals( "deepList 3 contents", datasetName, datasetList3.get( 0 ));
-
+			final List<String> datasetList3 = Arrays.asList(n5.deepList(prefix));
+			for (final String subGroup : subGroupNames)
+				Assert.assertTrue("deepList contents", datasetList3.contains("group/" + subGroup));
+			Assert.assertTrue("deepList contents", datasetList3.contains(datasetName.replaceFirst(prefix + "/", "")));
 
 			// parallel deepList tests
-			final List< String > datasetListP = n5.deepListParallel( "/", Executors.newFixedThreadPool( 2 ) );
-			Assert.assertEquals( "deepList size", 1, datasetListP.size());
-			Assert.assertEquals( "deepList contents", datasetName, datasetListP.get(0));
+			final List<String> datasetListP = Arrays.asList(n5.deepListParallel("/", Executors.newFixedThreadPool(2)));
+			for (final String subGroup : subGroupNames)
+				Assert.assertTrue("deepList contents", datasetListP.contains(groupName.replaceFirst("/", "") + "/" + subGroup));
+			Assert.assertTrue("deepList contents", datasetListP.contains(datasetName.replaceFirst("/", "")));
 
-			final List< String > datasetListP2 = n5.deepListParallel( "", Executors.newFixedThreadPool( 2 ) );
-			Assert.assertEquals( "deepList 2 size", 1, datasetListP2.size());
-			Assert.assertEquals( "deepList 2 contents", datasetName, datasetListP2.get(0));
+			final List<String> datasetListP2 = Arrays.asList(n5.deepListParallel("", Executors.newFixedThreadPool(2)));
+			for (final String subGroup : subGroupNames)
+				Assert.assertTrue("deepList contents", datasetListP2.contains(groupName.replaceFirst("/", "") + "/" + subGroup));
+			Assert.assertTrue("deepList contents", datasetListP2.contains(datasetName.replaceFirst("/", "")));
 
-			final List< String > datasetListP3 = n5.deepListParallel( prefix, Executors.newFixedThreadPool( 2 ) );
-			Assert.assertEquals( "deepList 3 size", 1, datasetListP3.size() );
-			Assert.assertEquals( "deepList 3 contents", datasetName, datasetListP3.get( 0 ));
+			final List<String> datasetListP3 = Arrays.asList(n5.deepListParallel(prefix, Executors.newFixedThreadPool(2)));
+			for (final String subGroup : subGroupNames)
+				Assert.assertTrue("deepList contents", datasetListP3.contains("group/" + subGroup));
+			Assert.assertTrue("deepList contents", datasetListP3.contains(datasetName.replaceFirst(prefix + "/", "")));
 
 		} catch (final IOException | InterruptedException | ExecutionException e) {
 			fail(e.getMessage());

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -24,8 +24,11 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 
 import org.janelia.saalfeldlab.n5.N5Reader.Version;
 import org.junit.AfterClass;
@@ -482,6 +485,32 @@ public abstract class AbstractN5Test {
 			// test listing the root group ("" and "/" should give identical results)
 			Assert.assertArrayEquals(new String[] {"test"}, n5.list(""));
 			Assert.assertArrayEquals(new String[] {"test"}, n5.list("/"));
+
+
+		} catch (final IOException e) {
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testDeepList() {
+
+		try {
+			n5.remove(groupName);
+			Assert.assertTrue( "deepList empty", n5.deepList("/").isEmpty() );
+
+			n5.createGroup(groupName);
+			for (final String subGroup : subGroupNames)
+				n5.createGroup(groupName + "/" + subGroup);
+
+			Assert.assertTrue( "deepList empty groups no datasets", n5.deepList("/").isEmpty() );
+
+			n5.createDataset(datasetName, dimensions, blockSize, DataType.UINT64, new RawCompression());
+
+			List< String > datasetList = n5.deepList( "/" );
+			Assert.assertEquals( "deepList size", 1, datasetList.size());
+			Assert.assertEquals( "deepList contents", datasetName, datasetList.get(0));
+
 		} catch (final IOException e) {
 			fail(e.getMessage());
 		}

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -507,11 +507,35 @@ public abstract class AbstractN5Test {
 
 			n5.createDataset(datasetName, dimensions, blockSize, DataType.UINT64, new RawCompression());
 
-			List< String > datasetList = n5.deepList( "/" );
+			final List< String > datasetList = n5.deepList( "/" );
 			Assert.assertEquals( "deepList size", 1, datasetList.size());
 			Assert.assertEquals( "deepList contents", datasetName, datasetList.get(0));
 
-		} catch (final IOException e) {
+			final List< String > datasetList2 = n5.deepList( "" );
+			Assert.assertEquals( "deepList 2 size", 1, datasetList2.size());
+			Assert.assertEquals( "deepList 2 contents", datasetName, datasetList2.get(0));
+
+			final String prefix = "/test";
+			final String suffix = "/group/dataset";
+			final List< String > datasetList3 = n5.deepList( prefix );
+			Assert.assertEquals( "deepList 3 size", 1, datasetList3.size() );
+			Assert.assertEquals( "deepList 3 contents", datasetName, datasetList3.get( 0 ));
+
+
+			// parallel deepList tests
+			final List< String > datasetListP = n5.deepListParallel( "/", Executors.newFixedThreadPool( 2 ) );
+			Assert.assertEquals( "deepList size", 1, datasetListP.size());
+			Assert.assertEquals( "deepList contents", datasetName, datasetListP.get(0));
+
+			final List< String > datasetListP2 = n5.deepListParallel( "", Executors.newFixedThreadPool( 2 ) );
+			Assert.assertEquals( "deepList 2 size", 1, datasetListP2.size());
+			Assert.assertEquals( "deepList 2 contents", datasetName, datasetListP2.get(0));
+
+			final List< String > datasetListP3 = n5.deepListParallel( prefix, Executors.newFixedThreadPool( 2 ) );
+			Assert.assertEquals( "deepList 3 size", 1, datasetListP3.size() );
+			Assert.assertEquals( "deepList 3 contents", datasetName, datasetListP3.get( 0 ));
+
+		} catch (final IOException | InterruptedException | ExecutionException e) {
 			fail(e.getMessage());
 		}
 	}

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -529,17 +529,17 @@ public abstract class AbstractN5Test {
 			Assert.assertTrue("deepList contents", datasetList3.contains(datasetName.replaceFirst(prefix + "/", "")));
 
 			// parallel deepList tests
-			final List<String> datasetListP = Arrays.asList(n5.deepListParallel("/", Executors.newFixedThreadPool(2)));
+			final List<String> datasetListP = Arrays.asList(n5.deepList("/", Executors.newFixedThreadPool(2)));
 			for (final String subGroup : subGroupNames)
 				Assert.assertTrue("deepList contents", datasetListP.contains(groupName.replaceFirst("/", "") + "/" + subGroup));
 			Assert.assertTrue("deepList contents", datasetListP.contains(datasetName.replaceFirst("/", "")));
 
-			final List<String> datasetListP2 = Arrays.asList(n5.deepListParallel("", Executors.newFixedThreadPool(2)));
+			final List<String> datasetListP2 = Arrays.asList(n5.deepList("", Executors.newFixedThreadPool(2)));
 			for (final String subGroup : subGroupNames)
 				Assert.assertTrue("deepList contents", datasetListP2.contains(groupName.replaceFirst("/", "") + "/" + subGroup));
 			Assert.assertTrue("deepList contents", datasetListP2.contains(datasetName.replaceFirst("/", "")));
 
-			final List<String> datasetListP3 = Arrays.asList(n5.deepListParallel(prefix, Executors.newFixedThreadPool(2)));
+			final List<String> datasetListP3 = Arrays.asList(n5.deepList(prefix, Executors.newFixedThreadPool(2)));
 			for (final String subGroup : subGroupNames)
 				Assert.assertTrue("deepList contents", datasetListP3.contains("group/" + subGroup));
 			Assert.assertTrue("deepList contents", datasetListP3.contains(datasetName.replaceFirst(prefix + "/", "")));


### PR DESCRIPTION
This PR adds a default method `deepList` to `N5Reader` which recursively returns all datasets that are children of the argument path.

It also provides a `deepListParallel` that performs the listing / dataset detection in parallel using an `ExecutorService`

## what's left to do
I'd like to check that high-latency (cloud) readers behave correctly - I've experienced issues in the past.