### PR TITLE
Bump scijava-pom to 31.1.0, jhdf5 to 19.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Chunked datasets can be sparse, i.e. empty chunks do not need to be stored.
 
 ## File-system specification
 
-*version 2.5.1-SNAPSHOT*
+*version 2.5.2-SNAPSHOT*
 
 N5 group is not a single file but simply a directory on the file system.  Meta-data is stored as a JSON file per each group/ directory.  Tensor datasets can be chunked and chunks are stored as individual files.  This enables parallel reading and writing on a cluster.
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>30.0.0</version>
+		<version>31.1.0</version>
 		<relativePath />
 	</parent>
 
@@ -102,6 +102,7 @@
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
+		<cisd.jhdf5.version>19.04.0</cisd.jhdf5.version>
 
 		<commons-collections4.version>4.2</commons-collections4.version>
 	</properties>
@@ -144,6 +145,7 @@
 		<dependency>
 			<groupId>cisd</groupId>
 			<artifactId>jhdf5</artifactId>
+			<version>${cisd.jhdf5.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
This updates the jhdf5 library to version 19.04.0 per scijava/pom-scijava#181

