### PR TITLE
fix: read multi-member gzip streams

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/GzipCompression.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/GzipCompression.java
@@ -75,7 +75,7 @@ public class GzipCompression implements DefaultBlockReader, DefaultBlockWriter, 
 		if (useZlib) {
 			return new InflaterInputStream(in);
 		} else {
-			return new GzipCompressorInputStream(in);
+			return new GzipCompressorInputStream(in,true);
 		}
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/GzipCompression.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/GzipCompression.java
@@ -75,7 +75,7 @@ public class GzipCompression implements DefaultBlockReader, DefaultBlockWriter, 
 		if (useZlib) {
 			return new InflaterInputStream(in);
 		} else {
-			return new GzipCompressorInputStream(in,true);
+			return new GzipCompressorInputStream(in, true);
 		}
 	}
 


### PR DESCRIPTION
Direct concatenation of gzip streams is a valid gzip stream [(see the gzip spec)](https://datatracker.ietf.org/doc/html/rfc1952#section-2.3).

Such streams currently fail with an `EOFException`, This PR enables such streams to be correctly read. 
<details>

<summary>the exception</summary>

```
Caused by: java.io.EOFException
	at java.io.DataInputStream.readFully(DataInputStream.java:197)
	at java.io.DataInputStream.readFully(DataInputStream.java:169)
	at org.janelia.saalfeldlab.n5.DefaultBlockReader.read(DefaultBlockReader.java:51)
	at org.janelia.saalfeldlab.n5.zarr.N5ZarrReader.readBlock(N5ZarrReader.java:350)
	at org.janelia.saalfeldlab.n5.zarr.N5ZarrReader.readBlock(N5ZarrReader.java:470)
	at org.janelia.saalfeldlab.n5.imglib2.N5CacheLoader.get(N5CacheLoader.java:117)
	at org.janelia.saalfeldlab.n5.imglib2.N5CacheLoader.get(N5CacheLoader.java:87)
	at net.imglib2.cache.ref.SoftRefLoaderCache.get(SoftRefLoaderCache.java:135)
```
</details>

Thanks @dmilkie for reporting this
