### PR TITLE
Container path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ hs_err_pid*
 .classpath
 .project
 .settings
+
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>31.1.0</version>
+		<version>34.0.0</version>
 		<relativePath />
 	</parent>
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/FileSystemKeyValueAccess.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/FileSystemKeyValueAccess.java
@@ -30,6 +30,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.OverlappingFileLockException;
@@ -268,6 +270,11 @@ public class FileSystemKeyValueAccess implements KeyValueAccess {
 	public String normalize(final String path) {
 
 		return fileSystem.getPath(path).normalize().toString();
+	}
+
+	@Override
+	public String absoluteURI(final String normalPath) throws URISyntaxException {
+		return new URI("file", null, normalPath, null).toString();
 	}
 
 	@Override

--- a/src/main/java/org/janelia/saalfeldlab/n5/KeyValueAccess.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/KeyValueAccess.java
@@ -106,7 +106,7 @@ public interface KeyValueAccess {
 	 * 		efforts are made to normalize it.
 	 * @return true if the path is a file
 	 */
-	public boolean isFile(String normalPath);
+	public boolean isFile(String normalPath); // TODO: Looks un-used. Remove?
 
 	/**
 	 * Create a lock on a path for reading.  This isn't meant to be kept
@@ -159,7 +159,7 @@ public interface KeyValueAccess {
 	 * @return the the child paths
 	 * @throws IOException the exception
 	 */
-	public String[] list(final String normalPath) throws IOException;
+	public String[] list(final String normalPath) throws IOException; // TODO: Looks un-used. Remove?
 
 	/**
 	 * Create a directory and all parent paths along the way.  The directory

--- a/src/main/java/org/janelia/saalfeldlab/n5/KeyValueAccess.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/KeyValueAccess.java
@@ -26,6 +26,7 @@
 package org.janelia.saalfeldlab.n5;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.FileSystem;
 
 /**
@@ -80,6 +81,15 @@ public interface KeyValueAccess {
 	 * @return the normalized path
 	 */
 	public String normalize(final String path);
+
+	/**
+	 * Get the absolute (including scheme) URI of the given path
+	 *
+	 * @param normalPath is expected to be in normalized form, no further
+	 * 		efforts are made to normalize it.
+	 * @return absolute URI
+	 */
+	public String absoluteURI(final String normalPath) throws URISyntaxException;
 
 	/**
 	 * Test whether the path exists.

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5KeyValueReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5KeyValueReader.java
@@ -27,11 +27,12 @@ package org.janelia.saalfeldlab.n5;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import java.net.URISyntaxException;
+import java.util.stream.Stream;
 import org.janelia.saalfeldlab.n5.cache.N5JsonCache;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.stream.Stream;
 
 /**
  * {@link N5Reader} implementation through {@link KeyValueAccess} with JSON
@@ -125,6 +126,7 @@ public class N5KeyValueReader implements CachedGsonKeyValueReader {
 
 		return gson;
 	}
+
 	public KeyValueAccess getKeyValueAccess() {
 		return keyValueAccess;
 	}
@@ -133,6 +135,16 @@ public class N5KeyValueReader implements CachedGsonKeyValueReader {
 	public String getBasePath() {
 
 		return this.basePath;
+	}
+
+	@Override
+	public String getContainerURI() {
+
+		try {
+			return keyValueAccess.absoluteURI(basePath);
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	@Override

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
@@ -217,6 +217,15 @@ public interface N5Reader extends AutoCloseable {
 	String getBasePath();
 
 	/**
+	 * Returns a String representation of the absolute URI of the container.
+	 *
+	 * @return the absolute URI of the container
+	 */
+	// TODO: should this throw URISyntaxException or can we assume that this is
+	//       never possible if we were able to instantiate this N5Reader?
+	String getContainerURI();
+
+	/**
 	 * Reads an attribute.
 	 *
 	 * @param pathName group path

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5URL.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5URL.java
@@ -614,4 +614,5 @@ public class N5URL {
 
 		return sb.toString();
 	}
+
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Writer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Writer.java
@@ -133,7 +133,7 @@ public interface N5Writer extends N5Reader {
 	/**
 	 * Removes a group or dataset (directory and all contained files).
 	 *
-	 * <p><code>{@link #remove(String) remove("")}</code> or
+	 * <p><code>{@link #remove(String) remove("/")}</code> or
 	 * <code>{@link #remove(String) remove("")}</code> will delete this N5
 	 * container.  Please note that no checks for safety will be performed,
 	 * e.g. <code>{@link #remove(String) remove("..")}</code> will try to

--- a/src/test/java/org/janelia/saalfeldlab/n5/N5FSTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/N5FSTest.java
@@ -29,10 +29,14 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -59,6 +63,38 @@ public class N5FSTest extends AbstractN5Test {
 	private static FileSystemKeyValueAccess access = new FileSystemKeyValueAccess(FileSystems.getDefault());
 	private static String testDirPath = tempN5PathName();
 
+	private static Set<String> tmpFiles = new HashSet<>();
+
+	private static String tempN5PathName()  {
+		try {
+			final File tmpFile = Files.createTempDirectory("n5-test-").toFile();
+			tmpFile.deleteOnExit();
+			final String tmpPath = tmpFile.getCanonicalPath();
+			tmpFiles.add(tmpPath);
+			return tmpPath;
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	protected String tempN5Location() throws URISyntaxException {
+		final String basePath = tempN5PathName();
+		return new URI("file", null, basePath, null).toString();
+	}
+
+	@Override
+	protected N5Writer createN5Writer(final String location, final GsonBuilder gson) throws IOException, URISyntaxException {
+		final String basePath = new File(new URI(location)).getCanonicalPath();
+		return new N5FSWriter(basePath, gson);
+	}
+
+	@Override
+	protected N5Reader createN5Reader(final String location, final GsonBuilder gson) throws IOException, URISyntaxException {
+		final String basePath = new File(new URI(location)).getCanonicalPath();
+		return new N5FSReader(basePath, gson);
+	}
+
 	@AfterClass
 	public static void cleanup() {
 
@@ -67,30 +103,6 @@ public class N5FSTest extends AbstractN5Test {
 				FileUtils.deleteDirectory(new File(tmpFile));
 			} catch (Exception e) { }
 		}
-	}
-
-	/**
-	 * @throws IOException
-	 */
-	@Override
-	protected N5Writer createN5Writer() throws IOException {
-		return new N5FSWriter(tempN5PathName(), false);
-	}
-
-
-
-
-	@Override
-	protected N5Writer createN5Writer(String location, GsonBuilder gson) throws IOException {
-		if (!new File(location).exists()) {
-			tmpFiles.add(location);
-		}
-		return new N5FSWriter(location, gson);
-	}
-
-	@Override
-	protected N5Reader createN5Reader(String location, GsonBuilder gson) throws IOException {
-		return new N5FSReader(location, gson);
 	}
 
 	@Test


### PR DESCRIPTION
This solves a problem I ran into with the AmazonS3 reader/writer implementation:
`N5Reader.getBasePath()` is not enough to extract the actual location out of a given `N5Reader`. In the S3 case, it was not possible to extract the bucket from a reader, because only the (S3)`KeyValueAccess` knows that.

This PR adds a method `N5Reader.getContainerURI()` which gives the full URL of the container (for example: "file://path/to/container.n5" or "s3://bucket/path/tocontainer.n5"). It uses `KeyValueAccess.absoluteURI(String)`, which returns the absolute URI of the given relative (to the "root" of the `KeyValueAccess`) path.

Also, the tests are fixed to use `N5Reader.getContainerURI()` and `AbstractN5Test.tempN5Location()`. The latter, I added to replace the filesystem-based `AbstractN5Test.tempN5PathName()` which bled into non-filesystem-related tests and complicated many things ... 