### PR TITLE
Use Junit5 to parametrize tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,8 +128,9 @@
 
 		<!-- Test dependencies -->
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.9.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -32,9 +32,6 @@ import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import org.janelia.saalfeldlab.n5.N5Reader.Version;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -51,14 +48,18 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.function.Predicate;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Abstract base class for testing N5 functionality.
@@ -121,8 +122,8 @@ public abstract class AbstractN5Test {
 	/**
 	 * @throws IOException
 	 */
-	@Before
-	public void setUpOnce() throws IOException, URISyntaxException {
+	@BeforeEach
+	public void setUp() throws IOException, URISyntaxException {
 
 		if (n5 != null)
 			return;
@@ -149,11 +150,11 @@ public abstract class AbstractN5Test {
 	/**
 	 * @throws IOException
 	 */
-	@AfterClass
-	public static void rampDownAfterClass() throws IOException {
+	@AfterAll
+	public static void rampDownGlobal() throws IOException {
 
 		if (n5 != null) {
-			try { 
+			try {
 				assertTrue(n5.remove());
 			} catch ( Exception e ) {}
 			n5 = null;
@@ -192,10 +193,7 @@ public abstract class AbstractN5Test {
 		final DatasetAttributes info;
 		try (N5Writer writer = createN5Writer()) {
 			writer.createDataset(datasetName, dimensions, blockSize, DataType.UINT64, new RawCompression());
-
-			if (!writer.exists(datasetName))
-				fail("Dataset does not exist");
-
+			assertTrue(writer.exists(datasetName), "Dataset does not exist");
 			info = writer.getDatasetAttributes(datasetName);
 		}
 		assertArrayEquals(dimensions, info.getDimensions());
@@ -852,10 +850,10 @@ public abstract class AbstractN5Test {
 
 			final List<String> groupsList = Arrays.asList(n5.deepList("/"));
 			for (final String subGroup : subGroupNames)
-				assertTrue("deepList contents", groupsList.contains(groupName.replaceFirst("/", "") + "/" + subGroup));
+				assertTrue(groupsList.contains(groupName.replaceFirst("/", "") + "/" + subGroup), "deepList contents");
 
 			for (final String subGroup : subGroupNames)
-				assertTrue("deepList contents", Arrays.asList(n5.deepList("")).contains(groupName.replaceFirst("/", "") + "/" + subGroup));
+				assertTrue(Arrays.asList(n5.deepList("")).contains(groupName.replaceFirst("/", "") + "/" + subGroup), "deepList contents");
 
 			final DatasetAttributes datasetAttributes = new DatasetAttributes(dimensions, blockSize, DataType.UINT64, new RawCompression());
 			final LongArrayDataBlock dataBlock = new LongArrayDataBlock(blockSize, new long[]{0, 0, 0}, new long[blockNumElements]);
@@ -864,41 +862,41 @@ public abstract class AbstractN5Test {
 
 			final List<String> datasetList = Arrays.asList(n5.deepList("/"));
 			for (final String subGroup : subGroupNames)
-				assertTrue("deepList contents", datasetList.contains(groupName.replaceFirst("/", "") + "/" + subGroup));
-			assertTrue("deepList contents", datasetList.contains(datasetName.replaceFirst("/", "")));
-			assertFalse("deepList stops at datasets", datasetList.contains(datasetName + "/0"));
+				assertTrue(datasetList.contains(groupName.replaceFirst("/", "") + "/" + subGroup), "deepList contents");
+			assertTrue(datasetList.contains(datasetName.replaceFirst("/", "")), "deepList contents");
+			assertFalse(datasetList.contains(datasetName + "/0"), "deepList stops at datasets");
 
 			final List<String> datasetList2 = Arrays.asList(n5.deepList(""));
 			for (final String subGroup : subGroupNames)
-				assertTrue("deepList contents", datasetList2.contains(groupName.replaceFirst("/", "") + "/" + subGroup));
-			assertTrue("deepList contents", datasetList2.contains(datasetName.replaceFirst("/", "")));
-			assertFalse("deepList stops at datasets", datasetList2.contains(datasetName + "/0"));
+				assertTrue(datasetList2.contains(groupName.replaceFirst("/", "") + "/" + subGroup), "deepList contents");
+			assertTrue(datasetList2.contains(datasetName.replaceFirst("/", "")), "deepList contents");
+			assertFalse(datasetList2.contains(datasetName + "/0"), "deepList stops at datasets");
 
 			final String prefix = "/test";
 			final String datasetSuffix = "group/dataset";
 			final List<String> datasetList3 = Arrays.asList(n5.deepList(prefix));
 			for (final String subGroup : subGroupNames)
-				assertTrue("deepList contents", datasetList3.contains("group/" + subGroup));
-			assertTrue("deepList contents", datasetList3.contains(datasetName.replaceFirst(prefix + "/", "")));
+				assertTrue(datasetList3.contains("group/" + subGroup), "deepList contents");
+			assertTrue(datasetList3.contains(datasetName.replaceFirst(prefix + "/", "")), "deepList contents");
 
 			// parallel deepList tests
 			final List<String> datasetListP = Arrays.asList(n5.deepList("/", Executors.newFixedThreadPool(2)));
 			for (final String subGroup : subGroupNames)
-				assertTrue("deepList contents", datasetListP.contains(groupName.replaceFirst("/", "") + "/" + subGroup));
-			assertTrue("deepList contents", datasetListP.contains(datasetName.replaceFirst("/", "")));
-			assertFalse("deepList stops at datasets", datasetListP.contains(datasetName + "/0"));
+				assertTrue(datasetListP.contains(groupName.replaceFirst("/", "") + "/" + subGroup), "deepList contents");
+			assertTrue(datasetListP.contains(datasetName.replaceFirst("/", "")), "deepList contents");
+			assertFalse(datasetListP.contains(datasetName + "/0"), "deepList stops at datasets");
 
 			final List<String> datasetListP2 = Arrays.asList(n5.deepList("", Executors.newFixedThreadPool(2)));
 			for (final String subGroup : subGroupNames)
-				assertTrue("deepList contents", datasetListP2.contains(groupName.replaceFirst("/", "") + "/" + subGroup));
-			assertTrue("deepList contents", datasetListP2.contains(datasetName.replaceFirst("/", "")));
-			assertFalse("deepList stops at datasets", datasetListP2.contains(datasetName + "/0"));
+				assertTrue(datasetListP2.contains(groupName.replaceFirst("/", "") + "/" + subGroup), "deepList contents");
+			assertTrue(datasetListP2.contains(datasetName.replaceFirst("/", "")), "deepList contents");
+			assertFalse(datasetListP2.contains(datasetName + "/0"), "deepList stops at datasets");
 
 			final List<String> datasetListP3 = Arrays.asList(n5.deepList(prefix, Executors.newFixedThreadPool(2)));
 			for (final String subGroup : subGroupNames)
-				assertTrue("deepList contents", datasetListP3.contains("group/" + subGroup));
-			assertTrue("deepList contents", datasetListP3.contains(datasetName.replaceFirst(prefix + "/", "")));
-			assertFalse("deepList stops at datasets", datasetListP3.contains(datasetName + "/0"));
+				assertTrue(datasetListP3.contains("group/" + subGroup), "deepList contents");
+			assertTrue(datasetListP3.contains(datasetName.replaceFirst(prefix + "/", "")), "deepList contents");
+			assertFalse(datasetListP3.contains(datasetName + "/0"), "deepList stops at datasets");
 
 			// test filtering
 			final Predicate<String> isCalledDataset = d -> {
@@ -910,31 +908,31 @@ public abstract class AbstractN5Test {
 
 			final List<String> datasetListFilter1 = Arrays.asList(n5.deepList(prefix, isCalledDataset));
 			assertTrue(
-					"deepList filter \"dataset\"",
-					datasetListFilter1.stream().map(x -> prefix + x).allMatch(isCalledDataset));
+					datasetListFilter1.stream().map(x -> prefix + x).allMatch(isCalledDataset),
+					"deepList filter \"dataset\"");
 
 			final List<String> datasetListFilter2 = Arrays.asList(n5.deepList(prefix, isBorC));
 			assertTrue(
-					"deepList filter \"b or c\"",
-					datasetListFilter2.stream().map(x -> prefix + x).allMatch(isBorC));
+					datasetListFilter2.stream().map(x -> prefix + x).allMatch(isBorC),
+					"deepList filter \"b or c\"");
 
 			final List<String> datasetListFilterP1 =
 					Arrays.asList(n5.deepList(prefix, isCalledDataset, Executors.newFixedThreadPool(2)));
 			assertTrue(
-					"deepList filter \"dataset\"",
-					datasetListFilterP1.stream().map(x -> prefix + x).allMatch(isCalledDataset));
+					datasetListFilterP1.stream().map(x -> prefix + x).allMatch(isCalledDataset),
+					"deepList filter \"dataset\"");
 
 			final List<String> datasetListFilterP2 =
 					Arrays.asList(n5.deepList(prefix, isBorC, Executors.newFixedThreadPool(2)));
 			assertTrue(
-					"deepList filter \"b or c\"",
-					datasetListFilterP2.stream().map(x -> prefix + x).allMatch(isBorC));
+					datasetListFilterP2.stream().map(x -> prefix + x).allMatch(isBorC),
+					"deepList filter \"b or c\"");
 
 			// test dataset filtering
 			final List<String> datasetListFilterD = Arrays.asList(n5.deepListDatasets(prefix));
 			assertTrue(
-					"deepListDataset",
-					datasetListFilterD.size() == 1 && (prefix + "/" + datasetListFilterD.get(0)).equals(datasetName));
+					datasetListFilterD.size() == 1 && (prefix + "/" + datasetListFilterD.get(0)).equals(datasetName),
+					"deepListDataset");
 			assertArrayEquals(
 					datasetListFilterD.toArray(),
 					n5.deepList(
@@ -948,7 +946,7 @@ public abstract class AbstractN5Test {
 							}));
 
 			final List<String> datasetListFilterDandBC = Arrays.asList(n5.deepListDatasets(prefix, isBorC));
-			assertTrue("deepListDatasetFilter", datasetListFilterDandBC.size() == 0);
+			assertEquals(0, datasetListFilterDandBC.size(), "deepListDatasetFilter");
 			assertArrayEquals(
 					datasetListFilterDandBC.toArray(),
 					n5.deepList(
@@ -964,8 +962,8 @@ public abstract class AbstractN5Test {
 			final List<String> datasetListFilterDP =
 					Arrays.asList(n5.deepListDatasets(prefix, Executors.newFixedThreadPool(2)));
 			assertTrue(
-					"deepListDataset Parallel",
-					datasetListFilterDP.size() == 1 && (prefix + "/" + datasetListFilterDP.get(0)).equals(datasetName));
+					datasetListFilterDP.size() == 1 && (prefix + "/" + datasetListFilterDP.get(0)).equals(datasetName),
+					"deepListDataset Parallel");
 			assertArrayEquals(
 					datasetListFilterDP.toArray(),
 					n5.deepList(
@@ -981,7 +979,7 @@ public abstract class AbstractN5Test {
 
 			final List<String> datasetListFilterDandBCP =
 					Arrays.asList(n5.deepListDatasets(prefix, isBorC, Executors.newFixedThreadPool(2)));
-			assertTrue("deepListDatasetFilter Parallel", datasetListFilterDandBCP.size() == 0);
+			assertEquals(0, datasetListFilterDandBCP.size(), "deepListDatasetFilter Parallel");
 			assertArrayEquals(
 					datasetListFilterDandBCP.toArray(),
 					n5.deepList(
@@ -1118,18 +1116,15 @@ public abstract class AbstractN5Test {
 			writer.removeAttribute("/", "/");
 			writer.setAttribute("/", N5Reader.VERSION_KEY,
 					new Version(N5Reader.VERSION.getMajor() + 1, N5Reader.VERSION.getMinor(), N5Reader.VERSION.getPatch()).toString());
-			assertThrows("Incompatible version throws error", N5Exception.N5IOException.class,
-					() -> {
-						createN5Reader(location);
-					});
+			assertThrows(N5Exception.N5IOException.class,
+						 () -> createN5Reader(location),
+						 "Incompatible version throws error");
 			writer.remove();
 		}
 		// non-existent group should fail
-		assertThrows("Non-existant location throws error", N5Exception.N5IOException.class,
-				() -> {
-					final N5Reader test = createN5Reader(location);
-					test.list("/");
-				});
+		assertThrows(N5Exception.N5IOException.class,
+					 () -> {final N5Reader test = createN5Reader(location);test.list("/");},
+					 "Non-existant location throws error");
 	}
 
 	@Test

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -58,6 +58,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -151,12 +152,12 @@ public abstract class AbstractN5Test {
 	 * @throws IOException
 	 */
 	@AfterAll
-	public static void rampDownGlobal() throws IOException {
+	public static void rampDownGlobal() {
 
 		if (n5 != null) {
 			try {
 				assertTrue(n5.remove());
-			} catch ( Exception e ) {}
+			} catch (Exception ignored) {}
 			n5 = null;
 		}
 	}
@@ -172,8 +173,7 @@ public abstract class AbstractN5Test {
 
 		final Path groupPath = Paths.get(groupName);
 		for (int i = 0; i < groupPath.getNameCount(); ++i)
-			if (!n5.exists(groupPath.subpath(0, i + 1).toString()))
-				fail("Group does not exist");
+			assertTrue(n5.exists(groupPath.subpath(0, i + 1).toString()), "Group does not exist");
 	}
 
 	@Test
@@ -217,7 +217,7 @@ public abstract class AbstractN5Test {
 					final ByteArrayDataBlock dataBlock = new ByteArrayDataBlock(blockSize, new long[]{0, 0, 0}, byteBlock);
 					n5.writeBlock(datasetName, attributes, dataBlock);
 
-					final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
+					final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, 0, 0, 0);
 
 					assertArrayEquals(byteBlock, (byte[])loadedDataBlock.getData());
 
@@ -246,7 +246,7 @@ public abstract class AbstractN5Test {
 					final ShortArrayDataBlock dataBlock = new ShortArrayDataBlock(blockSize, new long[]{0, 0, 0}, shortBlock);
 					n5.writeBlock(datasetName, attributes, dataBlock);
 
-					final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
+					final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, 0, 0, 0);
 
 					assertArrayEquals(shortBlock, (short[])loadedDataBlock.getData());
 
@@ -275,7 +275,7 @@ public abstract class AbstractN5Test {
 					final IntArrayDataBlock dataBlock = new IntArrayDataBlock(blockSize, new long[]{0, 0, 0}, intBlock);
 					n5.writeBlock(datasetName, attributes, dataBlock);
 
-					final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
+					final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, 0, 0, 0);
 
 					assertArrayEquals(intBlock, (int[])loadedDataBlock.getData());
 
@@ -304,7 +304,7 @@ public abstract class AbstractN5Test {
 					final LongArrayDataBlock dataBlock = new LongArrayDataBlock(blockSize, new long[]{0, 0, 0}, longBlock);
 					n5.writeBlock(datasetName, attributes, dataBlock);
 
-					final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
+					final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, 0, 0, 0);
 
 					assertArrayEquals(longBlock, (long[])loadedDataBlock.getData());
 
@@ -329,7 +329,7 @@ public abstract class AbstractN5Test {
 				final FloatArrayDataBlock dataBlock = new FloatArrayDataBlock(blockSize, new long[]{0, 0, 0}, floatBlock);
 				n5.writeBlock(datasetName, attributes, dataBlock);
 
-				final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
+				final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, 0, 0, 0);
 
 				assertArrayEquals(floatBlock, (float[])loadedDataBlock.getData(), 0.001f);
 
@@ -353,7 +353,7 @@ public abstract class AbstractN5Test {
 				final DoubleArrayDataBlock dataBlock = new DoubleArrayDataBlock(blockSize, new long[]{0, 0, 0}, doubleBlock);
 				n5.writeBlock(datasetName, attributes, dataBlock);
 
-				final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
+				final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, 0, 0, 0);
 
 				assertArrayEquals(doubleBlock, (double[])loadedDataBlock.getData(), 0.001);
 
@@ -383,7 +383,7 @@ public abstract class AbstractN5Test {
 					final ByteArrayDataBlock dataBlock = new ByteArrayDataBlock(differentBlockSize, new long[]{0, 0, 0}, byteBlock);
 					n5.writeBlock(datasetName, attributes, dataBlock);
 
-					final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
+					final DataBlock<?> loadedDataBlock = n5.readBlock(datasetName, attributes, 0, 0, 0);
 
 					assertArrayEquals(byteBlock, (byte[])loadedDataBlock.getData());
 
@@ -414,11 +414,11 @@ public abstract class AbstractN5Test {
 				object.get("one").add(new double[]{1, 2, 3});
 				object.get("two").add(new double[]{4, 5, 6, 7, 8});
 
-				n5.writeSerializedBlock(object, datasetName, attributes, new long[]{0, 0, 0});
+				n5.writeSerializedBlock(object, datasetName, attributes, 0, 0, 0);
 
 				final HashMap<String, ArrayList<double[]>> loadedObject = n5.readSerializedBlock(datasetName, attributes, new long[]{0, 0, 0});
 
-				object.entrySet().stream().forEach(e -> assertArrayEquals(e.getValue().get(0), loadedObject.get(e.getKey()).get(0), 0.01));
+				object.forEach((key, value) -> assertArrayEquals(value.get(0), loadedObject.get(key).get(0), 0.01));
 
 				assertTrue(n5.remove(datasetName));
 
@@ -438,13 +438,13 @@ public abstract class AbstractN5Test {
 
 			final IntArrayDataBlock randomDataBlock = new IntArrayDataBlock(blockSize, new long[]{0, 0, 0}, intBlock);
 			n5.writeBlock(datasetName, attributes, randomDataBlock);
-			final DataBlock<?> loadedRandomDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
+			final DataBlock<?> loadedRandomDataBlock = n5.readBlock(datasetName, attributes, 0, 0, 0);
 			assertArrayEquals(intBlock, (int[])loadedRandomDataBlock.getData());
 
 			// test the case where the resulting file becomes shorter
 			final IntArrayDataBlock emptyDataBlock = new IntArrayDataBlock(blockSize, new long[]{0, 0, 0}, new int[DataBlock.getNumElements(blockSize)]);
 			n5.writeBlock(datasetName, attributes, emptyDataBlock);
-			final DataBlock<?> loadedEmptyDataBlock = n5.readBlock(datasetName, attributes, new long[]{0, 0, 0});
+			final DataBlock<?> loadedEmptyDataBlock = n5.readBlock(datasetName, attributes, 0, 0, 0);
 			assertArrayEquals(new int[DataBlock.getNumElements(blockSize)], (int[])loadedEmptyDataBlock.getData());
 
 			assertTrue(n5.remove(datasetName));
@@ -568,8 +568,8 @@ public abstract class AbstractN5Test {
 			}.getType()));
 
 			// test the case where the resulting file becomes shorter
-			n5.setAttribute(groupName, "key1", Integer.valueOf(1));
-			n5.setAttribute(groupName, "key2", Integer.valueOf(2));
+			n5.setAttribute(groupName, "key1", 1);
+			n5.setAttribute(groupName, "key2", 2);
 			assertEquals(3, n5.listAttributes(groupName).size());
 			/* class interface */
 			assertEquals(Integer.valueOf(1), n5.getAttribute(groupName, "key1", Integer.class));
@@ -810,15 +810,12 @@ public abstract class AbstractN5Test {
 		try (final N5Writer n5 = createN5Writer()) {
 			n5.createDataset(datasetName, dimensions, blockSize, DataType.UINT64, new RawCompression());
 			n5.remove(groupName);
-			if (n5.exists(groupName)) {
-				fail("Group still exists");
-			}
+			assertFalse(n5.exists(groupName), "Group still exists");
 		}
-
 	}
 
 	@Test
-	public void testList() throws IOException, URISyntaxException {
+	public void testList() throws URISyntaxException {
 
 		try (final N5Writer listN5 = createN5Writer()) {
 			listN5.createGroup(groupName);
@@ -873,7 +870,6 @@ public abstract class AbstractN5Test {
 			assertFalse(datasetList2.contains(datasetName + "/0"), "deepList stops at datasets");
 
 			final String prefix = "/test";
-			final String datasetSuffix = "group/dataset";
 			final List<String> datasetList3 = Arrays.asList(n5.deepList(prefix));
 			for (final String subGroup : subGroupNames)
 				assertTrue(datasetList3.contains("group/" + subGroup), "deepList contents");
@@ -899,12 +895,8 @@ public abstract class AbstractN5Test {
 			assertFalse(datasetListP3.contains(datasetName + "/0"), "deepList stops at datasets");
 
 			// test filtering
-			final Predicate<String> isCalledDataset = d -> {
-				return d.endsWith("/dataset");
-			};
-			final Predicate<String> isBorC = d -> {
-				return d.matches(".*/[bc]$");
-			};
+			final Predicate<String> isCalledDataset = d -> d.endsWith("/dataset");
+			final Predicate<String> isBorC = d -> d.matches(".*/[bc]$");
 
 			final List<String> datasetListFilter1 = Arrays.asList(n5.deepList(prefix, isCalledDataset));
 			assertTrue(
@@ -1033,14 +1025,14 @@ public abstract class AbstractN5Test {
 			n5.setAttribute(datasetName2, "attr8", new Object[]{"1", 2, 3.1});
 
 			Map<String, Class<?>> attributesMap = n5.listAttributes(datasetName2);
-			assertTrue(attributesMap.get("attr1") == double[].class);
-			assertTrue(attributesMap.get("attr2") == String[].class);
-			assertTrue(attributesMap.get("attr3") == double.class);
-			assertTrue(attributesMap.get("attr4") == String.class);
-			assertTrue(attributesMap.get("attr5") == long[].class);
-			assertTrue(attributesMap.get("attr6") == long.class);
-			assertTrue(attributesMap.get("attr7") == double[].class);
-			assertTrue(attributesMap.get("attr8") == Object[].class);
+			assertSame(attributesMap.get("attr1"), double[].class);
+			assertSame(attributesMap.get("attr2"), String[].class);
+			assertSame(attributesMap.get("attr3"), double.class);
+			assertSame(attributesMap.get("attr4"), String.class);
+			assertSame(attributesMap.get("attr5"), long[].class);
+			assertSame(attributesMap.get("attr6"), long.class);
+			assertSame(attributesMap.get("attr7"), double[].class);
+			assertSame(attributesMap.get("attr8"), Object[].class);
 
 			n5.createGroup(groupName2);
 			n5.setAttribute(groupName2, "attr1", new double[]{1.1, 2.1, 3.1});
@@ -1053,14 +1045,14 @@ public abstract class AbstractN5Test {
 			n5.setAttribute(groupName2, "attr8", new Object[]{"1", 2, 3.1});
 
 			attributesMap = n5.listAttributes(groupName2);
-			assertTrue(attributesMap.get("attr1") == double[].class);
-			assertTrue(attributesMap.get("attr2") == String[].class);
-			assertTrue(attributesMap.get("attr3") == double.class);
-			assertTrue(attributesMap.get("attr4") == String.class);
-			assertTrue(attributesMap.get("attr5") == long[].class);
-			assertTrue(attributesMap.get("attr6") == long.class);
-			assertTrue(attributesMap.get("attr7") == double[].class);
-			assertTrue(attributesMap.get("attr8") == Object[].class);
+			assertSame(attributesMap.get("attr1"), double[].class);
+			assertSame(attributesMap.get("attr2"), String[].class);
+			assertSame(attributesMap.get("attr3"), double.class);
+			assertSame(attributesMap.get("attr4"), String.class);
+			assertSame(attributesMap.get("attr5"), long[].class);
+			assertSame(attributesMap.get("attr6"), long.class);
+			assertSame(attributesMap.get("attr7"), double[].class);
+			assertSame(attributesMap.get("attr8"), Object[].class);
 		} catch (final IOException e) {
 			fail(e.getMessage());
 		}
@@ -1073,7 +1065,7 @@ public abstract class AbstractN5Test {
 
 			final Version n5Version = writer.getVersion();
 
-			assertTrue(n5Version.equals(N5Reader.VERSION));
+			assertEquals(n5Version, N5Reader.VERSION);
 
 			final Version incompatibleVersion = new Version(N5Reader.VERSION.getMajor() + 1, N5Reader.VERSION.getMinor(), N5Reader.VERSION.getPatch());
 			writer.setAttribute("/", N5Reader.VERSION_KEY, incompatibleVersion.toString());
@@ -1165,7 +1157,7 @@ public abstract class AbstractN5Test {
 		return dataBlock == null;
 	}
 
-	public class TestData<T> {
+	public static class TestData<T> {
 
 		public String groupPath;
 		public String attributePath;
@@ -1406,7 +1398,7 @@ public abstract class AbstractN5Test {
 		final String basePath = ((N5FSWriter)n5).getBasePath();
 		try {
 			return new String(Files.readAllBytes(Paths.get(basePath, group, "attributes.json")));
-		} catch (IOException e) {
+		} catch (IOException ignored) {
 		}
 		return null;
 	}
@@ -1430,7 +1422,7 @@ public abstract class AbstractN5Test {
 			n5.setAttribute(groupName, "/", true);
 			final JsonElement booleanPrimitive =  n5.getAttribute(groupName, "/", JsonElement.class);
 			assertTrue(booleanPrimitive.isJsonPrimitive());
-			assertEquals(true, booleanPrimitive.getAsBoolean());
+			assertTrue(booleanPrimitive.getAsBoolean());
 			n5.setAttribute(groupName, "/",  null);
 			final JsonElement jsonNull =  n5.getAttribute(groupName, "/", JsonElement.class);
 			assertTrue(jsonNull.isJsonNull());

--- a/src/test/java/org/janelia/saalfeldlab/n5/FileSystemKeyValueAccessTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/FileSystemKeyValueAccessTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
  */
 public class FileSystemKeyValueAccessTest {
 
-	private static String[] testPaths = new String[] {
+	private static final String[] testPaths = new String[] {
 			"/test/path/file",
 			"test/path/file",
 			"/test/path/file/",
@@ -33,7 +33,7 @@ public class FileSystemKeyValueAccessTest {
 //			Paths.get("C:", "test", "path", "file").toString()
 	};
 
-	private static String[][] testPathComponents = new String[][] {
+	private static final String[][] testPathComponents = new String[][] {
 			{"/", "test", "path", "file"},
 			{"test", "path", "file"},
 			{"/", "test", "path", "file"},
@@ -61,7 +61,7 @@ public class FileSystemKeyValueAccessTest {
 
 		for (int i = 0; i <  testPaths.length; ++i) {
 
-			System.out.println(String.format("%d: %s -> %s", i, testPaths[i], Arrays.toString(access.components(testPaths[i]))));
+			System.out.printf("%d: %s -> %s%n", i, testPaths[i], Arrays.toString(access.components(testPaths[i])));
 
 			assertArrayEquals(testPathComponents[i], access.components(testPaths[i]));
 		}

--- a/src/test/java/org/janelia/saalfeldlab/n5/FileSystemKeyValueAccessTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/FileSystemKeyValueAccessTest.java
@@ -3,13 +3,13 @@
  */
 package org.janelia.saalfeldlab.n5;
 
-import static org.junit.Assert.assertArrayEquals;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.FileSystems;
 import java.util.Arrays;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 
 /**
@@ -51,7 +51,7 @@ public class FileSystemKeyValueAccessTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@BeforeClass
+	@BeforeAll
 	public static void setUpBeforeClass() throws Exception {}
 
 	@Test

--- a/src/test/java/org/janelia/saalfeldlab/n5/N5Benchmark.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/N5Benchmark.java
@@ -25,8 +25,6 @@
  */
 package org.janelia.saalfeldlab.n5;
 
-import static org.junit.Assert.fail;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -35,11 +33,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 import ch.systemsx.cisd.base.mdarray.MDShortArray;
 import ch.systemsx.cisd.hdf5.HDF5Factory;
@@ -55,6 +48,13 @@ import net.imglib2.img.imageplus.ImagePlusImg;
 import net.imglib2.img.imageplus.ImagePlusImgs;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.view.Views;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  *
@@ -91,8 +91,8 @@ public class N5Benchmark {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@BeforeClass
-	public static void setUpBeforeClass() throws Exception {
+	@BeforeAll
+	public static void setUpGlobal() throws Exception {
 
 		final File testDir = new File(testDirPath);
 		testDir.mkdirs();
@@ -112,8 +112,8 @@ public class N5Benchmark {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@AfterClass
-	public static void rampDownAfterClass() throws Exception {
+	@AfterAll
+	public static void rampDownGlobal() throws Exception {
 
 		n5.remove("");
 	}
@@ -121,7 +121,7 @@ public class N5Benchmark {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {}
 
 	/**

--- a/src/test/java/org/janelia/saalfeldlab/n5/N5Benchmark.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/N5Benchmark.java
@@ -63,7 +63,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class N5Benchmark {
 
-	private static String testDirPath;
+	private static final String testDirPath;
 
 	static {
 		try {
@@ -73,7 +73,7 @@ public class N5Benchmark {
 		}
 	}
 
-	private static String datasetName = "/dataset";
+	private static final String datasetName = "/dataset";
 
 	private static N5Writer n5;
 
@@ -166,7 +166,7 @@ public class N5Benchmark {
 				} catch (final IOException e) {
 					fail(e.getMessage());
 				}
-				System.out.println(String.format("%d : %s : %fs", i, compression.getType(), 0.001 * (System.currentTimeMillis() - t)));
+				System.out.printf("%d : %s : %fs%n", i, compression.getType(), 0.001 * (System.currentTimeMillis() - t));
 			}
 
 			/* TIF blocks */
@@ -179,7 +179,7 @@ public class N5Benchmark {
 						final ImagePlus impBlock = new ImagePlus("", new ShortProcessor(64, 64 * 64, data, null));
 						IJ.saveAsTiff(impBlock, compressedDatasetName + "/" + x + "-" + y + "-" + z + ".tif");
 					}
-			System.out.println(String.format("%d : tif : %fs", i, 0.001 * (System.currentTimeMillis() - t)));
+			System.out.printf("%d : tif : %fs%n", i, 0.001 * (System.currentTimeMillis() - t));
 
 			/* HDF5 raw */
 			t = System.currentTimeMillis();
@@ -197,7 +197,7 @@ public class N5Benchmark {
 						final MDShortArray targetCell = new MDShortArray(data, new int[]{64, 64, 64});
 						uint16Writer.writeMDArrayBlockWithOffset(datasetName, targetCell, new long[]{64 * z, 64 * y, 64 * x});
 					}
-			System.out.println(String.format("%d : hdf5 raw : %fs", i, 0.001 * (System.currentTimeMillis() - t)));
+			System.out.printf("%d : hdf5 raw : %fs%n", i, 0.001 * (System.currentTimeMillis() - t));
 			new File(hdf5Name).delete();
 
 			/* HDF5 gzip */
@@ -216,7 +216,7 @@ public class N5Benchmark {
 						final MDShortArray targetCell = new MDShortArray(data, new int[]{64, 64, 64});
 						uint16Writer.writeMDArrayBlockWithOffset(datasetName, targetCell, new long[]{64 * z, 64 * y, 64 * x});
 					}
-			System.out.println(String.format("%d : hdf5 gzip : %fs", i, 0.001 * (System.currentTimeMillis() - t)));
+			System.out.printf("%d : hdf5 gzip : %fs%n", i, 0.001 * (System.currentTimeMillis() - t));
 			new File(hdf5Name).delete();
 		}
 	}
@@ -259,7 +259,7 @@ public class N5Benchmark {
 					for (final Future<Boolean> f : futures)
 						f.get();
 
-					System.out.println(String.format("%d : %s : %fs", i, compression.getType(), 0.001 * (System.currentTimeMillis() - t)));
+					System.out.printf("%d : %s : %fs%n", i, compression.getType(), 0.001 * (System.currentTimeMillis() - t));
 				} catch (final IOException | InterruptedException | ExecutionException e) {
 					fail(e.getMessage());
 				}
@@ -290,7 +290,7 @@ public class N5Benchmark {
 				for (final Future<Boolean> f : futures)
 					f.get();
 
-				System.out.println(String.format("%d : tif : %fs", i, 0.001 * (System.currentTimeMillis() - t)));
+				System.out.printf("%d : tif : %fs%n", i, 0.001 * (System.currentTimeMillis() - t));
 			} catch (final InterruptedException | ExecutionException e) {
 				fail(e.getMessage());
 			}
@@ -327,7 +327,7 @@ public class N5Benchmark {
 					f.get();
 
 				hdf5Writer.close();
-				System.out.println(String.format("%d : hdf5 raw : %fs", i, 0.001 * (System.currentTimeMillis() - t)));
+				System.out.printf("%d : hdf5 raw : %fs%n", i, 0.001 * (System.currentTimeMillis() - t));
 				new File(hdf5Name).delete();
 			} catch (final InterruptedException | ExecutionException e) {
 				fail(e.getMessage());
@@ -365,7 +365,7 @@ public class N5Benchmark {
 					f.get();
 
 				hdf5Writer.close();
-				System.out.println(String.format("%d : hdf5 gzip : %fs", i, 0.001 * (System.currentTimeMillis() - t)));
+				System.out.printf("%d : hdf5 gzip : %fs%n", i, 0.001 * (System.currentTimeMillis() - t));
 				new File(hdf5Name).delete();
 			} catch (final InterruptedException | ExecutionException e) {
 				fail(e.getMessage());

--- a/src/test/java/org/janelia/saalfeldlab/n5/N5CachedFSTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/N5CachedFSTest.java
@@ -1,21 +1,22 @@
 package org.janelia.saalfeldlab.n5;
 
 import com.google.gson.GsonBuilder;
+import org.junit.jupiter.api.Test;
+
 import java.net.URI;
 import java.net.URISyntaxException;
-import org.junit.Test;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class N5CachedFSTest extends N5FSTest {
 

--- a/src/test/java/org/janelia/saalfeldlab/n5/N5CachedFSTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/N5CachedFSTest.java
@@ -92,7 +92,7 @@ public class N5CachedFSTest extends N5FSTest {
 
 		final String tmpLocation = tempN5Location();
 		try (N5KeyValueWriter w1 = (N5KeyValueWriter) createN5Writer(tmpLocation);
-				N5KeyValueWriter w2 = (N5KeyValueWriter) createN5Writer(tmpLocation);) {
+				N5KeyValueWriter w2 = (N5KeyValueWriter) createN5Writer(tmpLocation)) {
 
 			// create a group, both writers know it exists
 			w1.createGroup(groupName);

--- a/src/test/java/org/janelia/saalfeldlab/n5/N5FSTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/N5FSTest.java
@@ -25,7 +25,6 @@
  */
 package org.janelia.saalfeldlab.n5;
 
-import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -45,12 +44,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.AfterClass;
-import org.junit.Test;
 import com.google.gson.GsonBuilder;
 import org.janelia.saalfeldlab.n5.url.UrlAttributeTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Initiates testing of the filesystem-based N5 implementation.
@@ -96,7 +97,7 @@ public class N5FSTest extends AbstractN5Test {
 		return new N5FSReader(basePath, gson);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void cleanup() {
 
 		for (String tmpFile : tmpFiles) {

--- a/src/test/java/org/janelia/saalfeldlab/n5/N5FSTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/N5FSTest.java
@@ -61,11 +61,11 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class N5FSTest extends AbstractN5Test {
 
-	private static FileSystemKeyValueAccess access = new FileSystemKeyValueAccess(FileSystems.getDefault());
+	private static final FileSystemKeyValueAccess access = new FileSystemKeyValueAccess(FileSystems.getDefault());
 
-	private static Set<String> tmpFiles = new HashSet<>();
+	private static final Set<String> tmpFiles = new HashSet<>();
 
-	private static String testDirPath = tempN5PathName();
+	private static final String testDirPath = tempN5PathName();
 
 	private static String tempN5PathName() {
 		try {
@@ -103,7 +103,7 @@ public class N5FSTest extends AbstractN5Test {
 		for (String tmpFile : tmpFiles) {
 			try{
 				FileUtils.deleteDirectory(new File(tmpFile));
-			} catch (Exception e) { }
+			} catch (Exception ignored) { }
 		}
 	}
 
@@ -129,12 +129,12 @@ public class N5FSTest extends AbstractN5Test {
 
 
 //	@Test
-	public void testReadLock() throws IOException, InterruptedException {
+	public void testReadLock() throws IOException {
 
 		final Path path = Paths.get(testDirPath, "lock");
 		try {
 			Files.delete(path);
-		} catch (final IOException e) {}
+		} catch (final IOException ignored) {}
 
 		LockedChannel lock = access.lockForWriting(path);
 		lock.close();
@@ -172,7 +172,7 @@ public class N5FSTest extends AbstractN5Test {
 		final Path path = Paths.get(testDirPath, "lock");
 		try {
 			Files.delete(path);
-		} catch (final IOException e) {}
+		} catch (final IOException ignored) {}
 
 		final LockedChannel lock = access.lockForWriting(path);
 		System.out.println("locked");
@@ -209,7 +209,7 @@ public class N5FSTest extends AbstractN5Test {
 		final Path path = Paths.get(testDirPath, "lock");
 		try {
 			Files.delete(path);
-		} catch (final IOException e) {}
+		} catch (final IOException ignored) {}
 
 		final LockedChannel lock = access.lockForWriting(path);
 
@@ -245,7 +245,7 @@ public class N5FSTest extends AbstractN5Test {
 		final Path path = Paths.get(testDirPath, "lock");
 		try {
 			Files.delete(path);
-		} catch (final IOException e) {}
+		} catch (final IOException ignored) {}
 
 		final LockedChannel lock = access.lockForWriting(path);
 

--- a/src/test/java/org/janelia/saalfeldlab/n5/N5URLTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/N5URLTest.java
@@ -1,12 +1,14 @@
 package org.janelia.saalfeldlab.n5;
 
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import java.net.URISyntaxException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 public class N5URLTest {
 	@Test
@@ -54,7 +56,7 @@ public class N5URLTest {
 		assertEquals("../..", N5URL.normalizeAttributePath("../result/../multiple/../.."));
 
 		String normalizedPath = N5URL.normalizeAttributePath("let's/try/a/some/////with/ /	//white spaces/");
-		assertEquals("Normalizing a normal path should be the identity", normalizedPath, N5URL.normalizeAttributePath(normalizedPath));
+		assertEquals(normalizedPath, N5URL.normalizeAttributePath(normalizedPath), "Normalizing a normal path should be the identity");
 	}
 
 	@Test

--- a/src/test/java/org/janelia/saalfeldlab/n5/cache/N5CacheTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/cache/N5CacheTest.java
@@ -1,10 +1,9 @@
 package org.janelia.saalfeldlab.n5.cache;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
-
 import com.google.gson.JsonElement;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class N5CacheTest {
 

--- a/src/test/java/org/janelia/saalfeldlab/n5/cache/N5CacheTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/cache/N5CacheTest.java
@@ -14,14 +14,14 @@ public class N5CacheTest {
 
 		final N5JsonCache cache = new N5JsonCache(backingStorage);
 
-		// check existance, ensure backing storage is only called once
+		// check existence, ensure backing storage is only called once
 		assertEquals(0, backingStorage.existsCallCount);
 		cache.exists("a","face");
 		assertEquals(1, backingStorage.existsCallCount);
 		cache.exists("a","face");
 		assertEquals(1, backingStorage.existsCallCount);
 
-		// check existance of new group, ensure backing storage is only called one more time
+		// check existence of new group, ensure backing storage is only called one more time
 		cache.exists("b","face");
 		assertEquals(2, backingStorage.existsCallCount);
 		cache.exists("b","face");

--- a/src/test/java/org/janelia/saalfeldlab/n5/compression/CompressionTypesTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/compression/CompressionTypesTest.java
@@ -8,11 +8,12 @@ import java.util.Map;
 
 import org.apache.commons.collections4.MapUtils;
 import org.janelia.saalfeldlab.n5.CompressionAdapter;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Stephan Saalfeld
@@ -23,28 +24,28 @@ public class CompressionTypesTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@BeforeClass
-	public static void setUpBeforeClass() throws Exception {
+	@BeforeAll
+	public static void setUpGlobal() throws Exception {
 	}
 
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@AfterClass
-	public static void tearDownAfterClass() throws Exception {
+	@AfterAll
+	public static void tearDownGlobal() throws Exception {
 	}
 
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 	}
 
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 

--- a/src/test/java/org/janelia/saalfeldlab/n5/url/UrlAttributeTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/url/UrlAttributeTest.java
@@ -14,13 +14,12 @@ import java.util.stream.Stream;
 import org.janelia.saalfeldlab.n5.N5FSWriter;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.N5URL;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UrlAttributeTest
 {
@@ -38,7 +37,7 @@ public class UrlAttributeTest
 
 	TestDoubles testObjDoubles;
 
-	@Before
+	@BeforeEach
 	public void before()
 	{
 		try
@@ -69,45 +68,45 @@ public class UrlAttributeTest
 		// get
 		Map< String, Object > everything = getAttribute( n5, new N5URL( "" ), Map.class );
 		final String version = N5Reader.VERSION.toString();
-		assertEquals( "empty url", version, everything.get( "n5" ) );
+		assertEquals( version, everything.get( "n5" ), "empty url" );
 
 		Map< String, Object > everything2 = getAttribute( n5, new N5URL( "#/" ), Map.class );
-		assertEquals( "root attribute", version, everything2.get( "n5" ) );
+		assertEquals( version, everything2.get( "n5" ), "root attribute" );
 
-		assertEquals( "url to attribute", "bar", getAttribute( n5, new N5URL( "#foo" ), String.class ) );
-		assertEquals( "url to attribute absolute", "bar", getAttribute( n5, new N5URL( "#/foo" ), String.class ) );
+		assertEquals( "bar", getAttribute( n5, new N5URL( "#foo" ), String.class ), "url to attribute" );
+		assertEquals( "bar", getAttribute( n5, new N5URL( "#/foo" ), String.class ), "url to attribute absolute" );
 
-		assertEquals( "#foo", "bar", getAttribute( n5, new N5URL( "#foo" ), String.class ) );
-		assertEquals( "#/foo", "bar", getAttribute( n5, new N5URL( "#/foo" ), String.class ) );
-		assertEquals( "?#foo", "bar", getAttribute( n5, new N5URL( "?#foo" ), String.class ) );
-		assertEquals( "?#/foo", "bar", getAttribute( n5, new N5URL( "?#/foo" ), String.class ) );
-		assertEquals( "?/#/foo", "bar", getAttribute( n5, new N5URL( "?/#/foo" ), String.class ) );
-		assertEquals( "?/.#/foo", "bar", getAttribute( n5, new N5URL( "?/.#/foo" ), String.class ) );
-		assertEquals( "?./#/foo", "bar", getAttribute( n5, new N5URL( "?./#/foo" ), String.class ) );
-		assertEquals( "?.#foo", "bar", getAttribute( n5, new N5URL( "?.#foo" ), String.class ) );
-		assertEquals( "?/a/..#foo", "bar", getAttribute( n5, new N5URL( "?/a/..#foo" ), String.class ) );
-		assertEquals( "?/a/../.#foo", "bar", getAttribute( n5, new N5URL( "?/a/../.#foo" ), String.class ) );
+		assertEquals( "bar", getAttribute( n5, new N5URL( "#foo" ), String.class ), "#foo" );
+		assertEquals( "bar", getAttribute( n5, new N5URL( "#/foo" ), String.class ), "#/foo" );
+		assertEquals( "bar", getAttribute( n5, new N5URL( "?#foo" ), String.class ), "?#foo" );
+		assertEquals( "bar", getAttribute( n5, new N5URL( "?#/foo" ), String.class ), "?#/foo" );
+		assertEquals( "bar", getAttribute( n5, new N5URL( "?/#/foo" ), String.class ), "?/#/foo" );
+		assertEquals( "bar", getAttribute( n5, new N5URL( "?/.#/foo" ), String.class ), "?/.#/foo" );
+		assertEquals( "bar", getAttribute( n5, new N5URL( "?./#/foo" ), String.class ), "?./#/foo" );
+		assertEquals( "bar", getAttribute( n5, new N5URL( "?.#foo" ), String.class ), "?.#foo" );
+		assertEquals( "bar", getAttribute( n5, new N5URL( "?/a/..#foo" ), String.class ), "?/a/..#foo" );
+		assertEquals( "bar", getAttribute( n5, new N5URL( "?/a/../.#foo" ), String.class ), "?/a/../.#foo" );
 
 		/* whitespace-encoding-necesary, fragment-only test*/
-		assertEquals( "#f o o", "b a r", getAttribute( n5, new N5URL( "#f o o" ), String.class ) );
+		assertEquals( "b a r", getAttribute( n5, new N5URL( "#f o o" ), String.class ), "#f o o" );
 
-		Assert.assertArrayEquals( "url list", list, getAttribute( n5, new N5URL( "#list" ), int[].class ) );
+		assertArrayEquals( list, getAttribute( n5, new N5URL( "#list" ), int[].class ), "url list" );
 
 		// list
-		assertEquals( "url list[0]", list[ 0 ], ( int ) getAttribute( n5, new N5URL( "#list[0]" ), Integer.class ) );
-		assertEquals( "url list[1]", list[ 1 ], ( int ) getAttribute( n5, new N5URL( "#list[1]" ), Integer.class ) );
-		assertEquals( "url list[2]", list[ 2 ], ( int ) getAttribute( n5, new N5URL( "#list[2]" ), Integer.class ) );
+		assertEquals( list[ 0 ], ( int ) getAttribute( n5, new N5URL( "#list[0]" ), Integer.class ), "url list[0]" );
+		assertEquals( list[ 1 ], ( int ) getAttribute( n5, new N5URL( "#list[1]" ), Integer.class ), "url list[1]" );
+		assertEquals( list[ 2 ], ( int ) getAttribute( n5, new N5URL( "#list[2]" ), Integer.class ), "url list[2]" );
 
-		assertEquals( "url list[3]", list[ 3 ], ( int ) getAttribute( n5, new N5URL( "#list[3]" ), Integer.class ) );
-		assertEquals( "url list/[3]", list[ 3 ], ( int ) getAttribute( n5, new N5URL( "#list/[3]" ), Integer.class ) );
-		assertEquals( "url list//[3]", list[ 3 ], ( int ) getAttribute( n5, new N5URL( "#list//[3]" ), Integer.class ) );
-		assertEquals( "url //list//[3]", list[ 3 ], ( int ) getAttribute( n5, new N5URL( "#//list//[3]" ), Integer.class ) );
-		assertEquals( "url //list//[3]//", list[ 3 ], ( int ) getAttribute( n5, new N5URL( "#//list////[3]//" ), Integer.class ) );
+		assertEquals( list[ 3 ], ( int ) getAttribute( n5, new N5URL( "#list[3]" ), Integer.class ), "url list[3]" );
+		assertEquals( list[ 3 ], ( int ) getAttribute( n5, new N5URL( "#list/[3]" ), Integer.class ), "url list/[3]" );
+		assertEquals( list[ 3 ], ( int ) getAttribute( n5, new N5URL( "#list//[3]" ), Integer.class ), "url list//[3]" );
+		assertEquals( list[ 3 ], ( int ) getAttribute( n5, new N5URL( "#//list//[3]" ), Integer.class ), "url //list//[3]" );
+		assertEquals( list[ 3 ], ( int ) getAttribute( n5, new N5URL( "#//list////[3]//" ), Integer.class ), "url //list//[3]//" );
 
 		// object
-		assertTrue( "url object", mapsEqual( obj, getAttribute( n5, new N5URL( "#object" ), Map.class ) ) );
-		assertEquals( "url object/a", "aa", getAttribute( n5, new N5URL( "#object/a" ), String.class ) );
-		assertEquals( "url object/b", "bb", getAttribute( n5, new N5URL( "#object/b" ), String.class ) );
+		assertTrue( mapsEqual( obj, getAttribute( n5, new N5URL( "#object" ), Map.class ) ), "url object" );
+		assertEquals( "aa", getAttribute( n5, new N5URL( "#object/a" ), String.class ), "url object/a" );
+		assertEquals( "bb", getAttribute( n5, new N5URL( "#object/b" ), String.class ), "url object/b" );
 	}
 
 	@Test
@@ -123,35 +122,35 @@ public class UrlAttributeTest
 		final N5URL aaaUrl = new N5URL( "?/a/aa/aaa" );
 
 		// name of a
-		assertEquals( "name of a from root", a, getAttribute( n5, "?/a#name", String.class ) );
-		assertEquals( "name of a from root", a, getAttribute( n5, new N5URL( "?a#name" ), String.class ) );
-		assertEquals( "name of a from a", a, getAttribute( n5, aUrl.resolve( new N5URL( "?/a#name" ) ), String.class ) );
-		assertEquals( "name of a from aa", a, getAttribute( n5, aaUrl.resolve( "?..#name" ), String.class ) );
-		assertEquals( "name of a from aaa", a, getAttribute( n5, aaaUrl.resolve( new N5URL( "?../..#name" ) ), String.class ) );
+		assertEquals( a, getAttribute( n5, "?/a#name", String.class ), "name of a from root" );
+		assertEquals( a, getAttribute( n5, new N5URL( "?a#name" ), String.class ), "name of a from root" );
+		assertEquals( a, getAttribute( n5, aUrl.resolve( new N5URL( "?/a#name" ) ), String.class ), "name of a from a" );
+		assertEquals( a, getAttribute( n5, aaUrl.resolve( "?..#name" ), String.class ), "name of a from aa" );
+		assertEquals( a, getAttribute( n5, aaaUrl.resolve( new N5URL( "?../..#name" ) ), String.class ), "name of a from aaa" );
 
 		// name of aa
-		assertEquals( "name of aa from root", aa, getAttribute( n5, new N5URL( "?/a/aa#name" ), String.class ) );
-		assertEquals( "name of aa from root", aa, getAttribute( n5, new N5URL( "?a/aa#name" ), String.class ) );
-		assertEquals( "name of aa from a", aa, getAttribute( n5, aUrl.resolve( "?aa#name" ), String.class ) );
+		assertEquals( aa, getAttribute( n5, new N5URL( "?/a/aa#name" ), String.class ), "name of aa from root" );
+		assertEquals( aa, getAttribute( n5, new N5URL( "?a/aa#name" ), String.class ), "name of aa from root" );
+		assertEquals( aa, getAttribute( n5, aUrl.resolve( "?aa#name" ), String.class ), "name of aa from a" );
 
-		assertEquals( "name of aa from aa", aa, getAttribute( n5, aaUrl.resolve( "?./#name" ), String.class ) );
+		assertEquals( aa, getAttribute( n5, aaUrl.resolve( "?./#name" ), String.class ), "name of aa from aa" );
 
-		assertEquals( "name of aa from aa", aa, getAttribute( n5, aaUrl.resolve( "#name" ), String.class ) );
-		assertEquals( "name of aa from aaa", aa, getAttribute( n5, aaaUrl.resolve( "?..#name" ), String.class ) );
+		assertEquals( aa, getAttribute( n5, aaUrl.resolve( "#name" ), String.class ), "name of aa from aa" );
+		assertEquals( aa, getAttribute( n5, aaaUrl.resolve( "?..#name" ), String.class ), "name of aa from aaa" );
 
 		// name of aaa
-		assertEquals( "name of aaa from root", aaa, getAttribute( n5, new N5URL( "?/a/aa/aaa#name" ), String.class ) );
-		assertEquals( "name of aaa from root", aaa, getAttribute( n5, new N5URL( "?a/aa/aaa#name" ), String.class ) );
-		assertEquals( "name of aaa from a", aaa, getAttribute( n5, aUrl.resolve( "?aa/aaa#name" ), String.class ) );
-		assertEquals( "name of aaa from aa", aaa, getAttribute( n5, aaUrl.resolve( "?aaa#name" ), String.class ) );
-		assertEquals( "name of aaa from aaa", aaa, getAttribute( n5, aaaUrl.resolve( "#name" ), String.class ) );
+		assertEquals( aaa, getAttribute( n5, new N5URL( "?/a/aa/aaa#name" ), String.class ), "name of aaa from root" );
+		assertEquals( aaa, getAttribute( n5, new N5URL( "?a/aa/aaa#name" ), String.class ), "name of aaa from root" );
+		assertEquals( aaa, getAttribute( n5, aUrl.resolve( "?aa/aaa#name" ), String.class ), "name of aaa from a" );
+		assertEquals( aaa, getAttribute( n5, aaUrl.resolve( "?aaa#name" ), String.class ), "name of aaa from aa" );
+		assertEquals( aaa, getAttribute( n5, aaaUrl.resolve( "#name" ), String.class ), "name of aaa from aaa" );
 
-		assertEquals( "name of aaa from aaa", aaa, getAttribute( n5, aaaUrl.resolve( "?./#name" ), String.class ) );
+		assertEquals( aaa, getAttribute( n5, aaaUrl.resolve( "?./#name" ), String.class ), "name of aaa from aaa" );
 
-		assertEquals( "nested list 1", (Integer)1, getAttribute( n5, new N5URL( "#nestedList[0][0][0]" ), Integer.class ) );
-		assertEquals( "nested list 1", (Integer)1, getAttribute( n5, new N5URL( "#/nestedList/[0][0][0]" ), Integer.class ) );
-		assertEquals( "nested list 1", (Integer)1, getAttribute( n5, new N5URL( "#nestedList//[0]/[0]///[0]" ), Integer.class ) );
-		assertEquals( "nested list 1", (Integer)1, getAttribute( n5, new N5URL( "#/nestedList[0]//[0][0]" ), Integer.class ) );
+		assertEquals( (Integer)1, getAttribute( n5, new N5URL( "#nestedList[0][0][0]" ), Integer.class ), "nested list 1" );
+		assertEquals( (Integer)1, getAttribute( n5, new N5URL( "#/nestedList/[0][0][0]" ), Integer.class ), "nested list 1" );
+		assertEquals( (Integer)1, getAttribute( n5, new N5URL( "#nestedList//[0]/[0]///[0]" ), Integer.class ), "nested list 1" );
+		assertEquals( (Integer)1, getAttribute( n5, new N5URL( "#/nestedList[0]//[0][0]" ), Integer.class ), "nested list 1" );
 
 	}
 

--- a/src/test/java/org/janelia/saalfeldlab/n5/url/UrlAttributeTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/url/UrlAttributeTest.java
@@ -199,9 +199,11 @@ public class UrlAttributeTest
 
 		final String[] stringArray = getAttribute( n5, new N5URL( "?objs#String" ), String[].class );
 		final String[] expectedString = new String[] { "This", "is", "a", "test" };
+		assertArrayEquals( expectedString, stringArray );
 
 		final Integer[] integerArray = getAttribute( n5, new N5URL( "?objs#Integer" ), Integer[].class );
 		final Integer[] expectedInteger = new Integer[] { 1, 2, 3, 4 };
+		assertArrayEquals( expectedInteger, integerArray );
 
 		final int[] intArray = getAttribute( n5, new N5URL( "?objs#int" ), int[].class );
 		final int[] expectedInt = new int[] { 1, 2, 3, 4 };


### PR DESCRIPTION
I played around with Junit5 today, mainly to familiarize myself with the framework a little bit. The main feature I was looking at is the possibility to parametrize tests. This has improved a lot in Junit5 over Junit4.

Given that there is quite some code-duplication in the unittests of this repo, parametrization could reduce the amount of code. This usually leads to the tests being more flexible, expressive and maintainable. Right now, as a proof of concept, I parametrized the `testWriteRead*` tests with the compression method. This has the following effects, which can be further improved by also parametrizing, e.g., with data types:
* Adding and removing compression methods stays as easy as it was before (where each test looped over all compression methods).
* Every compression method spawns its own test with automatic (but custom chosen) names. The advantage here is that one immediately sees the exact parameters for failed tests and that these can be re-run in isolation for debugging.
* The `for`-loops in the tests are gone, leading to fewer lines of code to maintain.

This PR is merely a draft without any goal other than getting to know the framework, which I think I achieved by now. But if a change to Junit5 is really desired, I'm happy to play around with the framework a little more and apply my insights to the unittests here.