### PR TITLE
fix: wrap unchecked IOExceptions as well (such as AccessDenied)

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/CachedGsonKeyValueN5Writer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/CachedGsonKeyValueN5Writer.java
@@ -26,6 +26,7 @@
 package org.janelia.saalfeldlab.n5;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 
 import org.janelia.saalfeldlab.n5.N5Exception.N5IOException;
@@ -72,7 +73,7 @@ public interface CachedGsonKeyValueN5Writer extends CachedGsonKeyValueN5Reader, 
 		 */
 		try {
 			getKeyValueAccess().createDirectories(absoluteGroupPath(normalPath));
-		} catch (final IOException e) {
+		} catch (final IOException | UncheckedIOException e) {
 			throw new N5Exception.N5IOException("Failed to create group " + path, e);
 		}
 
@@ -146,7 +147,7 @@ public interface CachedGsonKeyValueN5Writer extends CachedGsonKeyValueN5Reader, 
 		try {
 			if (getKeyValueAccess().isDirectory(groupPath))
 				getKeyValueAccess().delete(groupPath);
-		} catch (final IOException e) {
+		} catch (final IOException | UncheckedIOException e) {
 			throw new N5IOException("Failed to remove " + path, e);
 		}
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/GsonKeyValueN5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/GsonKeyValueN5Reader.java
@@ -26,6 +26,7 @@
 package org.janelia.saalfeldlab.n5;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 
 import org.janelia.saalfeldlab.n5.N5Exception.N5IOException;
@@ -80,7 +81,7 @@ public interface GsonKeyValueN5Reader extends GsonN5Reader {
 
 		try (final LockedChannel lockedChannel = getKeyValueAccess().lockForReading(attributesPath)) {
 			return GsonUtils.readAttributes(lockedChannel.newReader(), getGson());
-		} catch (final IOException e) {
+		} catch (final IOException | UncheckedIOException e) {
 			throw new N5IOException("Failed to read attributes from dataset " + pathName, e);
 		}
 
@@ -98,7 +99,7 @@ public interface GsonKeyValueN5Reader extends GsonN5Reader {
 
 		try (final LockedChannel lockedChannel = getKeyValueAccess().lockForReading(path)) {
 			return DefaultBlockReader.readBlock(lockedChannel.newInputStream(), datasetAttributes, gridPosition);
-		} catch (final IOException e) {
+		} catch (final IOException | UncheckedIOException e) {
 			throw new N5IOException(
 					"Failed to read block " + Arrays.toString(gridPosition) + " from dataset " + path,
 					e);
@@ -110,7 +111,7 @@ public interface GsonKeyValueN5Reader extends GsonN5Reader {
 
 		try {
 			return getKeyValueAccess().listDirectories(absoluteGroupPath(pathName));
-		} catch (final IOException e) {
+		} catch (final IOException | UncheckedIOException e) {
 			throw new N5IOException("Cannot list directories for group " + pathName, e);
 		}
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/GsonKeyValueN5Writer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/GsonKeyValueN5Writer.java
@@ -26,6 +26,7 @@
 package org.janelia.saalfeldlab.n5;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -72,7 +73,7 @@ public interface GsonKeyValueN5Writer extends GsonN5Writer, GsonKeyValueN5Reader
 		final String normalPath = N5URI.normalizeGroupPath(path);
 		try {
 			getKeyValueAccess().createDirectories(absoluteGroupPath(normalPath));
-		} catch (final IOException e) {
+		} catch (final IOException | UncheckedIOException e) {
 			throw new N5Exception.N5IOException("Failed to create group " + path, e);
 		}
 	}
@@ -96,7 +97,7 @@ public interface GsonKeyValueN5Writer extends GsonN5Writer, GsonKeyValueN5Reader
 
 		try (final LockedChannel lock = getKeyValueAccess().lockForWriting(absoluteAttributesPath(normalGroupPath))) {
 			GsonUtils.writeAttributes(lock.newWriter(), attributes, getGson());
-		} catch (final IOException e) {
+		} catch (final IOException | UncheckedIOException e) {
 			throw new N5Exception.N5IOException("Failed to write attributes into " + normalGroupPath, e);
 		}
 	}
@@ -218,7 +219,7 @@ public interface GsonKeyValueN5Writer extends GsonN5Writer, GsonKeyValueN5Reader
 		final String blockPath = absoluteDataBlockPath(N5URI.normalizeGroupPath(path), dataBlock.getGridPosition());
 		try (final LockedChannel lock = getKeyValueAccess().lockForWriting(blockPath)) {
 			DefaultBlockWriter.writeBlock(lock.newOutputStream(), datasetAttributes, dataBlock);
-		} catch (final IOException e) {
+		} catch (final IOException | UncheckedIOException e) {
 			throw new N5IOException(
 					"Failed to write block " + Arrays.toString(dataBlock.getGridPosition()) + " into dataset " + path,
 					e);
@@ -233,7 +234,7 @@ public interface GsonKeyValueN5Writer extends GsonN5Writer, GsonKeyValueN5Reader
 		try {
 			if (getKeyValueAccess().isDirectory(groupPath))
 				getKeyValueAccess().delete(groupPath);
-		} catch (final IOException e) {
+		} catch (final IOException | UncheckedIOException e) {
 			throw new N5IOException("Failed to remove " + path, e);
 		}
 
@@ -250,7 +251,7 @@ public interface GsonKeyValueN5Writer extends GsonN5Writer, GsonKeyValueN5Reader
 		try {
 			if (getKeyValueAccess().isFile(blockPath))
 				getKeyValueAccess().delete(blockPath);
-		} catch (final IOException e) {
+		} catch (final IOException | UncheckedIOException e) {
 			throw new N5IOException(
 					"Failed to delete block " + Arrays.toString(gridPosition) + " from dataset " + path,
 					e);

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Exception.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Exception.java
@@ -40,12 +40,12 @@ public class N5Exception extends RuntimeException {
 			super(message);
 		}
 
-		public N5IOException(final String message, final IOException cause) {
+		public N5IOException(final String message, final Exception cause) {
 
 			super(message, cause);
 		}
 
-		public N5IOException(final IOException cause) {
+		public N5IOException(final Exception cause) {
 
 			super(cause);
 		}

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
@@ -29,6 +29,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
+import java.io.UncheckedIOException;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.ArrayList;
@@ -324,7 +325,7 @@ public interface N5Reader extends AutoCloseable {
 		final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(block.toByteBuffer().array());
 		try (ObjectInputStream in = new ObjectInputStream(byteArrayInputStream)) {
 			return (T)in.readObject();
-		} catch (final IOException e) {
+		} catch (final IOException | UncheckedIOException e) {
 			throw new N5Exception.N5IOException(e);
 		}
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Writer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Writer.java
@@ -29,6 +29,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -280,7 +281,7 @@ public interface N5Writer extends N5Reader {
 		final ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
 		try (ObjectOutputStream out = new ObjectOutputStream(byteOutputStream)) {
 			out.writeObject(object);
-		} catch (final IOException e) {
+		} catch (final IOException | UncheckedIOException e) {
 			throw new N5Exception.N5IOException(e);
 		}
 		final byte[] bytes = byteOutputStream.toByteArray();


### PR DESCRIPTION
AccessDeniedExceptions are UncheckedIOExceptions, and were not being wrapped by N5IOExceptions. This causes unexpected errors, such as deepList failing when unable to read nested n5 groups.