### PR TITLE
Add ZstdCompression based on Apache Commons Compress

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,12 @@
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
 		</dependency>
+		<dependency>
+		    <groupId>com.github.luben</groupId>
+		    <artifactId>zstd-jni</artifactId>
+		    <version>1.5.5-10</version>
+		    <scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<repositories>

--- a/src/main/java/org/janelia/saalfeldlab/n5/ZstdCompression.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/ZstdCompression.java
@@ -1,0 +1,90 @@
+package org.janelia.saalfeldlab.n5;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.apache.commons.compress.compressors.zstandard.ZstdCompressorInputStream;
+import org.apache.commons.compress.compressors.zstandard.ZstdCompressorOutputStream;
+import org.janelia.saalfeldlab.n5.Compression.CompressionType;
+
+/**
+ * Zstandard compression for N5
+ * 
+ * Implementation wrapper around Apache Commons Compress
+ * 
+ * Note that zstd-jni is an optional dependency of Apache Commons Compress.
+ * However, it is required for this class, ZstdCompression, to work
+ * https://github.com/luben/zstd-jni
+ * 
+ * Add the following dependency entry under to the Maven pom.xml
+ * 
+ *		<dependency>
+ *		    <groupId>com.github.luben</groupId>
+ *		    <artifactId>zstd-jni</artifactId>
+ *		    <version>1.5.5-10</version>
+ *		</dependency>
+ * 
+ * See the Zstandard manual for details on parameters.
+ * https://facebook.github.io/zstd/zstd_manual.html
+ * 
+ * @author mkitti
+ *
+ */
+@CompressionType("zstd")
+public class ZstdCompression implements DefaultBlockReader, DefaultBlockWriter, Compression {
+	
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 8592416400988371189L;
+
+	/*
+	 * Compression level
+	 * 
+	 * Standard compression level is between 1 and 22
+	 * Negative compression levels offer speed
+	 * 
+	 * Note that zarr-developers/numcodecs defaults to 1
+	 * 
+	 * Default: 3 (see ZSTD_CLEVEL_DEFAULT)
+	 */
+	@CompressionParameter
+	private int level = 3;
+	
+	/*
+	 * Default compression level from zstd.h
+	 */
+	public static final int ZSTD_CLEVEL_DEFAULT = 3;
+	
+	public ZstdCompression() {
+		this.level = ZSTD_CLEVEL_DEFAULT;
+	}
+	
+	public ZstdCompression(int level) {
+		this.level = level;
+	}
+
+	@Override
+	public BlockReader getReader() {
+		return this;
+	}
+
+	@Override
+	public BlockWriter getWriter() {
+		return this;
+	}
+
+	@Override
+	public OutputStream getOutputStream(OutputStream out) throws IOException {
+		ZstdCompressorOutputStream zstdOut = new ZstdCompressorOutputStream(out, level);
+		return zstdOut;
+	}
+
+	@Override
+	public InputStream getInputStream(InputStream in) throws IOException {
+		ZstdCompressorInputStream zstdIn = new ZstdCompressorInputStream(in);
+		return zstdIn;
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/n5/ZstdCompression.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/ZstdCompression.java
@@ -19,11 +19,13 @@ import org.janelia.saalfeldlab.n5.Compression.CompressionType;
  * 
  * Add the following dependency entry under to the Maven pom.xml
  * 
+ * <pre>{@code
  *		<dependency>
  *		    <groupId>com.github.luben</groupId>
  *		    <artifactId>zstd-jni</artifactId>
  *		    <version>1.5.5-10</version>
  *		</dependency>
+ * }</pre>
  * 
  * See the Zstandard manual for details on parameters.
  * https://facebook.github.io/zstd/zstd_manual.html
@@ -34,12 +36,9 @@ import org.janelia.saalfeldlab.n5.Compression.CompressionType;
 @CompressionType("zstd")
 public class ZstdCompression implements DefaultBlockReader, DefaultBlockWriter, Compression {
 	
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 8592416400988371189L;
 
-	/*
+	/**
 	 * Compression level
 	 * 
 	 * Standard compression level is between 1 and 22
@@ -52,15 +51,21 @@ public class ZstdCompression implements DefaultBlockReader, DefaultBlockWriter, 
 	@CompressionParameter
 	private int level = 3;
 	
-	/*
+	/**
 	 * Default compression level from zstd.h
 	 */
 	public static final int ZSTD_CLEVEL_DEFAULT = 3;
 	
+	/**
+	 * Create Zstandard compression with level equal to the constant ZSTD_CLEVEL_DEFAULT (value: {@value ZstdCompression#ZSTD_CLEVEL_DEFAULT})
+	 */
 	public ZstdCompression() {
 		this.level = ZSTD_CLEVEL_DEFAULT;
 	}
 	
+	/**
+	 * @param level The standard compression levels are normally between 1 to 22. Negative compression levels offer greater speed.
+	 */
 	public ZstdCompression(int level) {
 		this.level = level;
 	}

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -115,7 +115,8 @@ public abstract class AbstractN5Test {
 				new GzipCompression(),
 				new GzipCompression(5, true),
 				new Lz4Compression(),
-				new XzCompression()
+				new XzCompression(),
+				new ZstdCompression()
 		};
 	}
 


### PR DESCRIPTION
Note tests will fail since the optional dependency zstd-jni
is not a dependency.

1. For this to work, I recommend at least adding zstd-jni as a test dependency. Without this patch, a4a5ac9 will fail tests. With this patch applied as in [e7abc25](https://github.com/saalfeldlab/n5/pull/111/commits/e7abc256c23df7a3e523790f935a79b06a807a5f) the tests will now succeed.

```diff
diff --git a/pom.xml b/pom.xml
index 17ededb..abde2d1 100644
--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,12 @@
                        <groupId>org.apache.commons</groupId>
                        <artifactId>commons-compress</artifactId>
                </dependency>
+               <dependency>
+                   <groupId>com.github.luben</groupId>
+                   <artifactId>zstd-jni</artifactId>
+                   <version>1.5.5-10</version>
+                   <scope>test</scope>
+               </dependency>
        </dependencies>
 
        <repositories>
```

2. We should also consider adding zstd-jni as an optional dependency of n5.
3. Another important parameter to consider is `nbWorkers` which controls the number of threads that Zstandard will use.
