### PR TITLE
fix: UnsupportedOperationException for blosc and strings

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/StringDataBlock.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/StringDataBlock.java
@@ -55,9 +55,13 @@ public class StringDataBlock extends AbstractDataBlock<String[]> {
 
     @Override
     public void readData(final ByteBuffer buffer) {
-        if (buffer.array() != serializedData)
-            buffer.get(serializedData);
-        actualData = deserialize(buffer.array());
+
+		if (buffer.hasArray()) {
+			if (buffer.array() != serializedData)
+				buffer.get(serializedData);
+			actualData = deserialize(buffer.array());
+		} else
+			actualData = ENCODING.decode(buffer).toString().split(NULLCHAR);
     }
 
     protected byte[] serialize(String[] strings) {


### PR DESCRIPTION
see https://github.com/saalfeldlab/n5-blosc/issues/7

This error was caused because the buffer not being backed by an accessible byte array.  The fix is to check if that is the case, and decode the buffer if not.