### PR TITLE
Less verbose message when compressor loading fails

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/CompressionAdapter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/CompressionAdapter.java
@@ -98,8 +98,7 @@ public class CompressionAdapter implements JsonDeserializer<Compression>, JsonSe
 					newInstance.compressionParameters.put(type, parameters);
 				} catch (final ClassNotFoundException | NoSuchMethodException | ClassCastException
 						| UnsatisfiedLinkError e) {
-					System.err.println("Compression '" + item.className() + "' could not be registered because:");
-					e.printStackTrace(System.err);
+					System.err.println("Compression '" + item.className() + "' could not be registered");
 				}
 			}
 


### PR DESCRIPTION
Its pretty common for n5 to output (benign) errors when making a reader or writer if it can't find libblosc, for example.

This PR makes the error shorter 

<details>
<summary>from this</summary>

```
Compression 'org.janelia.saalfeldlab.n5.blosc.BloscCompression' could not be registered because:
java.lang.UnsatisfiedLinkError: Unable to load library 'blosc':
libblosc.so: cannot open shared object file: No such file or directory
libblosc.so: cannot open shared object file: No such file or directory
Native library (linux-x86-64/libblosc.so) not found in resource path ([file:/home/john/dev/n5/n5-universe/target/test-classes/, file:/home/john/dev/n5/n5-universe/target/classes/, file:/home/john/.m2/repository/org/janelia/saalfeldlab/n5/3.2.0/n5-3.2.0.jar, file:/home/john/.m2/repository/org/tukaani/xz/1.9/xz-1.9.jar, file:/home/john/.m2/repository/org/lz4/lz4-java/1.8.0/lz4-java-1.8.0.jar, file:/home/john/.m2/repository/com/google/code/gson/gson/2.10.1/gson-2.10.1.jar, file:/home/john/.m2/repository/org/scijava/scijava-common/2.97.0/scijava-common-2.97.0.jar, file:/home/john/.m2/repository/org/scijava/parsington/3.1.0/parsington-3.1.0.jar, file:/home/john/.m2/repository/org/apache/commons/commons-compress/1.23.0/commons-compress-1.23.0.jar, file:/home/john/.m2/repository/org/janelia/saalfeldlab/n5-aws-s3/4.1.1/n5-aws-s3-4.1.1.jar, file:/home/john/.m2/repository/com/amazonaws/aws-java-sdk-s3/1.12.465/aws-java-sdk-s3-1.12.465.jar, file:/home/john/.m2/repository/com/amazonaws/aws-java-sdk-kms/1.12.465/aws-java-sdk-kms-1.12.465.jar, file:/home/john/.m2/repository/com/amazonaws/aws-java-sdk-core/1.12.465/aws-java-sdk-core-1.12.465.jar, file:/home/john/.m2/repository/software/amazon/ion/ion-java/1.0.2/ion-java-1.0.2.jar, file:/home/john/.m2/repository/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.14.2/jackson-dataformat-cbor-2.14.2.jar, file:/home/john/.m2/repository/joda-time/joda-time/2.12.5/joda-time-2.12.5.jar, file:/home/john/.m2/repository/com/amazonaws/jmespath-java/1.12.465/jmespath-java-1.12.465.jar, file:/home/john/.m2/repository/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar, file:/home/john/.m2/repository/org/janelia/saalfeldlab/n5-google-cloud/4.1.0/n5-google-cloud-4.1.0.jar, file:/home/john/.m2/repository/com/google/cloud/google-cloud-storage/2.22.1/google-cloud-storage-2.22.1.jar, file:/home/john/.m2/repository/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar, file:/home/john/.m2/repository/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar, file:/home/john/.m2/repository/com/google/errorprone/error_prone_annotations/2.19.0/error_prone_annotations-2.19.0.jar, file:/home/john/.m2/repository/com/google/j2objc/j2objc-annotations/2.8/j2objc-annotations-2.8.jar, file:/home/john/.m2/repository/io/opencensus/opencensus-contrib-http-util/0.31.1/opencensus-contrib-http-util-0.31.1.jar, file:/home/john/.m2/repository/com/google/http-client/google-http-client-jackson2/1.43.1/google-http-client-jackson2-1.43.1.jar, file:/home/john/.m2/repository/com/google/api-client/google-api-client/2.2.0/google-api-client-2.2.0.jar, file:/home/john/.m2/repository/commons-codec/commons-codec/1.15/commons-codec-1.15.jar, file:/home/john/.m2/repository/com/google/oauth-client/google-oauth-client/1.34.1/google-oauth-client-1.34.1.jar, file:/home/john/.m2/repository/com/google/http-client/google-http-client-apache-v2/1.43.1/google-http-client-apache-v2-1.43.1.jar, file:/home/john/.m2/repository/com/google/auto/value/auto-value-annotations/1.10.1/auto-value-annotations-1.10.1.jar, file:/home/john/.m2/repository/com/google/cloud/google-cloud-core-http/2.16.0/google-cloud-core-http-2.16.0.jar, file:/home/john/.m2/repository/com/google/http-client/google-http-client-appengine/1.43.1/google-http-client-appengine-1.43.1.jar, file:/home/john/.m2/repository/com/google/api/gax-httpjson/0.111.0/gax-httpjson-0.111.0.jar, file:/home/john/.m2/repository/com/google/cloud/google-cloud-core-grpc/2.16.0/google-cloud-core-grpc-2.16.0.jar, file:/home/john/.m2/repository/com/google/api/gax-grpc/2.26.0/gax-grpc-2.26.0.jar, file:/home/john/.m2/repository/io/grpc/grpc-alts/1.54.0/grpc-alts-1.54.0.jar, file:/home/john/.m2/repository/io/grpc/grpc-grpclb/1.54.0/grpc-grpclb-1.54.0.jar, file:/home/john/.m2/repository/org/conscrypt/conscrypt-openjdk-uber/2.5.2/conscrypt-openjdk-uber-2.5.2.jar, file:/home/john/.m2/repository/io/grpc/grpc-auth/1.54.0/grpc-auth-1.54.0.jar, file:/home/john/.m2/repository/io/grpc/grpc-protobuf/1.54.0/grpc-protobuf-1.54.0.jar, file:/home/john/.m2/repository/io/grpc/grpc-protobuf-lite/1.54.0/grpc-protobuf-lite-1.54.0.jar, file:/home/john/.m2/repository/com/google/auth/google-auth-library-credentials/1.16.1/google-auth-library-credentials-1.16.1.jar, file:/home/john/.m2/repository/com/google/auth/google-auth-library-oauth2-http/1.16.1/google-auth-library-oauth2-http-1.16.1.jar, file:/home/john/.m2/repository/com/google/api/api-common/2.9.0/api-common-2.9.0.jar, file:/home/john/.m2/repository/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar, file:/home/john/.m2/repository/io/opencensus/opencensus-api/0.31.1/opencensus-api-0.31.1.jar, file:/home/john/.m2/repository/io/grpc/grpc-context/1.55.1/grpc-context-1.55.1.jar, file:/home/john/.m2/repository/com/google/api/grpc/proto-google-iam-v1/1.12.0/proto-google-iam-v1-1.12.0.jar, file:/home/john/.m2/repository/com/google/protobuf/protobuf-java/3.23.0/protobuf-java-3.23.0.jar, file:/home/john/.m2/repository/com/google/protobuf/protobuf-java-util/3.23.0/protobuf-java-util-3.23.0.jar, file:/home/john/.m2/repository/com/google/api/grpc/proto-google-common-protos/2.17.0/proto-google-common-protos-2.17.0.jar, file:/home/john/.m2/repository/org/threeten/threetenbp/1.6.8/threetenbp-1.6.8.jar, file:/home/john/.m2/repository/com/google/api/grpc/proto-google-cloud-storage-v2/2.22.1-alpha/proto-google-cloud-storage-v2-2.22.1-alpha.jar, file:/home/john/.m2/repository/com/google/api/grpc/grpc-google-cloud-storage-v2/2.22.1-alpha/grpc-google-cloud-storage-v2-2.22.1-alpha.jar, file:/home/john/.m2/repository/com/google/api/grpc/gapic-google-cloud-storage-v2/2.22.1-alpha/gapic-google-cloud-storage-v2-2.22.1-alpha.jar, file:/home/john/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.14.2/jackson-core-2.14.2.jar, file:/home/john/.m2/repository/io/grpc/grpc-api/1.54.0/grpc-api-1.54.0.jar, file:/home/john/.m2/repository/io/grpc/grpc-netty-shaded/1.54.0/grpc-netty-shaded-1.54.0.jar, file:/home/john/.m2/repository/io/perfmark/perfmark-api/0.26.0/perfmark-api-0.26.0.jar, file:/home/john/.m2/repository/io/grpc/grpc-core/1.54.0/grpc-core-1.54.0.jar, file:/home/john/.m2/repository/com/google/android/annotations/4.1.1.4/annotations-4.1.1.4.jar, file:/home/john/.m2/repository/org/codehaus/mojo/animal-sniffer-annotations/1.23/animal-sniffer-annotations-1.23.jar, file:/home/john/.m2/repository/io/grpc/grpc-stub/1.54.0/grpc-stub-1.54.0.jar, file:/home/john/.m2/repository/io/grpc/grpc-googleapis/1.54.0/grpc-googleapis-1.54.0.jar, file:/home/john/.m2/repository/org/checkerframework/checker-qual/3.34.0/checker-qual-3.34.0.jar, file:/home/john/.m2/repository/io/grpc/grpc-xds/1.54.0/grpc-xds-1.54.0.jar, file:/home/john/.m2/repository/io/opencensus/opencensus-proto/0.2.0/opencensus-proto-0.2.0.jar, file:/home/john/.m2/repository/io/grpc/grpc-services/1.54.0/grpc-services-1.54.0.jar, file:/home/john/.m2/repository/com/google/re2j/re2j/1.7/re2j-1.7.jar, file:/home/john/.m2/repository/com/google/cloud/google-cloud-resourcemanager/1.18.0/google-cloud-resourcemanager-1.18.0.jar, file:/home/john/.m2/repository/com/google/api/grpc/proto-google-cloud-resourcemanager-v3/1.18.0/proto-google-cloud-resourcemanager-v3-1.18.0.jar, file:/home/john/.m2/repository/com/google/apis/google-api-services-cloudresourcemanager/v1-rev20230129-2.0.0/google-api-services-cloudresourcemanager-v1-rev20230129-2.0.0.jar, file:/home/john/.m2/repository/org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar, file:/home/john/.m2/repository/commons-logging/commons-logging/1.2/commons-logging-1.2.jar, file:/home/john/.m2/repository/org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar, file:/home/john/.m2/repository/org/janelia/saalfeldlab/n5-imglib2/7.0.0/n5-imglib2-7.0.0.jar, file:/home/john/.m2/repository/net/imglib2/imglib2-label-multisets/0.11.5/imglib2-label-multisets-0.11.5.jar, file:/home/john/.m2/repository/net/sf/trove4j/trove4j/3.0.3/trove4j-3.0.3.jar, file:/home/john/.m2/repository/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar, file:/home/john/.m2/repository/net/imglib2/imglib2/6.2.0/imglib2-6.2.0.jar, file:/home/john/.m2/repository/net/imglib2/imglib2-cache/1.0.0-beta-17/imglib2-cache-1.0.0-beta-17.jar, file:/home/john/.m2/repository/com/github/ben-manes/caffeine/caffeine/2.9.3/caffeine-2.9.3.jar, file:/home/john/.m2/repository/org/scijava/scijava-optional/1.0.1/scijava-optional-1.0.1.jar, file:/home/john/.m2/repository/net/imglib2/imglib2-realtransform/4.0.1/imglib2-realtransform-4.0.1.jar, file:/home/john/.m2/repository/gov/nist/math/jama/1.0.3/jama-1.0.3.jar, file:/home/john/.m2/repository/jitk/jitk-tps/3.0.3/jitk-tps-3.0.3.jar, file:/home/john/.m2/repository/com/googlecode/efficient-java-matrix-library/ejml/0.25/ejml-0.25.jar, file:/home/john/.m2/repository/org/janelia/saalfeldlab/n5-hdf5/2.2.0/n5-hdf5-2.2.0.jar, file:/home/john/.m2/repository/cisd/jhdf5/19.04.1/jhdf5-19.04.1.jar, file:/home/john/.m2/repository/cisd/base/18.09.0/base-18.09.0.jar, file:/home/john/.m2/repository/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar, file:/home/john/.m2/repository/org/janelia/saalfeldlab/n5-zarr/1.3.1/n5-zarr-1.3.1.jar, file:/home/john/dev/n5/n5-blosc/target/classes/, file:/home/john/.m2/repository/org/lasersonlab/jblosc/1.0.1/jblosc-1.0.1.jar, file:/home/john/.m2/repository/net/java/dev/jna/jna/5.13.0/jna-5.13.0.jar, file:/home/john/.m2/repository/org/janelia/n5-zstandard/1.0.2/n5-zstandard-1.0.2.jar, file:/home/john/.m2/repository/com/github/luben/zstd-jni/1.5.5-10/zstd-jni-1.5.5-10.jar, file:/home/john/.m2/repository/net/thisptr/jackson-jq/1.0.0-preview.20191208/jackson-jq-1.0.0-preview.20191208.jar, file:/home/john/.m2/repository/org/jruby/joni/joni/2.1.48/joni-2.1.48.jar, file:/home/john/.m2/repository/org/jruby/jcodings/jcodings/1.0.58/jcodings-1.0.58.jar, file:/home/john/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.14.2/jackson-databind-2.14.2.jar, file:/home/john/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.14.2/jackson-annotations-2.14.2.jar, file:/home/john/.m2/repository/se/sawano/java/alphanumeric-comparator/1.4.1/alphanumeric-comparator-1.4.1.jar, file:/home/john/.m2/repository/org/janelia/saalfeldlab/n5/3.2.0/n5-3.2.0-tests.jar, file:/home/john/.m2/repository/org/janelia/saalfeldlab/n5-zarr/1.3.1/n5-zarr-1.3.1-tests.jar, file:/home/john/.m2/repository/org/janelia/saalfeldlab/n5-aws-s3/4.1.1/n5-aws-s3-4.1.1-tests.jar, file:/home/john/.m2/repository/org/janelia/saalfeldlab/n5-google-cloud/4.1.0/n5-google-cloud-4.1.0-tests.jar, file:/home/john/.m2/repository/com/google/cloud/google-cloud-nio/0.126.14/google-cloud-nio-0.126.14.jar, file:/home/john/.m2/repository/com/google/apis/google-api-services-storage/v1-rev20230301-2.0.0/google-api-services-storage-v1-rev20230301-2.0.0.jar, file:/home/john/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar, file:/home/john/.m2/repository/com/google/api/gax/2.26.0/gax-2.26.0.jar, file:/home/john/.m2/repository/com/google/cloud/google-cloud-core/2.16.0/google-cloud-core-2.16.0.jar, file:/home/john/.m2/repository/com/google/http-client/google-http-client/1.43.1/google-http-client-1.43.1.jar, file:/home/john/.m2/repository/com/google/http-client/google-http-client-gson/1.43.1/google-http-client-gson-1.43.1.jar, file:/home/john/.m2/repository/javax/inject/javax.inject/1/javax.inject-1.jar, file:/home/john/.m2/repository/org/janelia/saalfeldlab/n5-hdf5/2.2.0/n5-hdf5-2.2.0-tests.jar, file:/home/john/.m2/repository/com/googlecode/json-simple/json-simple/1.1.1/json-simple-1.1.1.jar, file:/home/john/.m2/repository/junit/junit/4.13.2/junit-4.13.2.jar, file:/home/john/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar, file:/home/john/.m2/repository/commons-io/commons-io/2.11.0/commons-io-2.11.0.jar, file:/home/john/.m2/repository/io/findify/s3mock_2.12/0.2.5/s3mock_2.12-0.2.5.jar, file:/home/john/.m2/repository/org/scala-lang/scala-library/2.12.4/scala-library-2.12.4.jar, file:/home/john/.m2/repository/com/typesafe/akka/akka-stream_2.12/2.5.11/akka-stream_2.12-2.5.11.jar, file:/home/john/.m2/repository/com/typesafe/akka/akka-actor_2.12/2.5.11/akka-actor_2.12-2.5.11.jar, file:/home/john/.m2/repository/com/typesafe/config/1.3.2/config-1.3.2.jar, file:/home/john/.m2/repository/org/scala-lang/modules/scala-java8-compat_2.12/0.8.0/scala-java8-compat_2.12-0.8.0.jar, file:/home/john/.m2/repository/com/typesafe/akka/akka-protobuf_2.12/2.5.11/akka-protobuf_2.12-2.5.11.jar, file:/home/john/.m2/repository/org/reactivestreams/reactive-streams/1.0.2/reactive-streams-1.0.2.jar, file:/home/john/.m2/repository/com/typesafe/ssl-config-core_2.12/0.2.2/ssl-config-core_2.12-0.2.2.jar, file:/home/john/.m2/repository/org/scala-lang/modules/scala-parser-combinators_2.12/1.0.4/scala-parser-combinators_2.12-1.0.4.jar, file:/home/john/.m2/repository/com/typesafe/akka/akka-http_2.12/10.1.0/akka-http_2.12-10.1.0.jar, file:/home/john/.m2/repository/com/typesafe/akka/akka-http-core_2.12/10.1.0/akka-http-core_2.12-10.1.0.jar, file:/home/john/.m2/repository/com/typesafe/akka/akka-parsing_2.12/10.1.0/akka-parsing_2.12-10.1.0.jar, file:/home/john/.m2/repository/org/scala-lang/modules/scala-xml_2.12/1.1.0/scala-xml_2.12-1.1.0.jar, file:/home/john/.m2/repository/com/github/pathikrit/better-files_2.12/3.4.0/better-files_2.12-3.4.0.jar, file:/home/john/.m2/repository/com/typesafe/scala-logging/scala-logging_2.12/3.8.0/scala-logging_2.12-3.8.0.jar, file:/home/john/.m2/repository/org/scala-lang/scala-reflect/2.12.4/scala-reflect-2.12.4.jar, file:/home/john/.m2/repository/org/iq80/leveldb/leveldb/0.10/leveldb-0.10.jar, file:/home/john/.m2/repository/org/iq80/leveldb/leveldb-api/0.10/leveldb-api-0.10.jar, file:/home/john/.m2/repository/javax/xml/bind/jaxb-api/2.2.2/jaxb-api-2.2.2.jar, file:/home/john/.m2/repository/javax/xml/stream/stax-api/1.0-2/stax-api-1.0-2.jar, file:/home/john/.m2/repository/javax/activation/activation/1.1/activation-1.1.jar])
	at com.sun.jna.NativeLibrary.loadLibrary(NativeLibrary.java:323)
	at com.sun.jna.NativeLibrary.getInstance(NativeLibrary.java:483)
	at com.sun.jna.Native.register(Native.java:1774)
	at com.sun.jna.Native.register(Native.java:1493)
	at org.blosc.IBloscDll.<clinit>(IBloscDll.java:15)
	at org.blosc.JBlosc.init(JBlosc.java:30)
	at org.blosc.JBlosc.<init>(JBlosc.java:24)
	at org.janelia.saalfeldlab.n5.blosc.BloscCompression.<clinit>(BloscCompression.java:70)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at org.janelia.saalfeldlab.n5.CompressionAdapter.update(CompressionAdapter.java:84)
	at org.janelia.saalfeldlab.n5.CompressionAdapter.update(CompressionAdapter.java:112)
	at org.janelia.saalfeldlab.n5.CompressionAdapter.getJsonAdapter(CompressionAdapter.java:182)
	at org.janelia.saalfeldlab.n5.zarr.ZarrKeyValueReader.addTypeAdapters(ZarrKeyValueReader.java:861)
	at org.janelia.saalfeldlab.n5.zarr.ZarrKeyValueReader.registerGson(ZarrKeyValueReader.java:853)
	at org.janelia.saalfeldlab.n5.zarr.ZarrKeyValueReader.<init>(ZarrKeyValueReader.java:168)
	at org.janelia.saalfeldlab.n5.zarr.ZarrKeyValueReader.<init>(ZarrKeyValueReader.java:152)
	at org.janelia.saalfeldlab.n5.zarr.ZarrKeyValueReader.<init>(ZarrKeyValueReader.java:228)
	at org.janelia.saalfeldlab.n5.universe.N5Factory.openReader(N5Factory.java:369)
	at org.janelia.saalfeldlab.n5.universe.N5Factory.openN5Container(N5Factory.java:539)
	at org.janelia.saalfeldlab.n5.universe.N5Factory.openReader(N5Factory.java:338)
	at org.janelia.saalfeldlab.n5.universe.N5Factory.openN5Container(N5Factory.java:556)
	at org.janelia.saalfeldlab.n5.universe.N5Factory.openReader(N5Factory.java:349)
	at TmpUniverse.makeReader(TmpUniverse.java:40)
	at TmpUniverse.main(TmpUniverse.java:29)
	Suppressed: java.lang.UnsatisfiedLinkError: libblosc.so: cannot open shared object file: No such file or directory
		at com.sun.jna.Native.open(Native Method)
		at com.sun.jna.NativeLibrary.loadLibrary(NativeLibrary.java:211)
		... 24 more
	Suppressed: java.lang.UnsatisfiedLinkError: libblosc.so: cannot open shared object file: No such file or directory
		at com.sun.jna.Native.open(Native Method)
		at com.sun.jna.NativeLibrary.loadLibrary(NativeLibrary.java:224)
		... 24 more
	Suppressed: java.io.IOException: Native library (linux-x86-64/libblosc.so) not found in resource path ([file:/home/john/dev/n5/n5-universe/target/test-classes/, file:/home/john/dev/n5/n5-universe/target/classes/, file:/home/john/.m2/repository/org/janelia/saalfeldlab/n5/3.2.0/n5-3.2.0.jar, file:/home/john/.m2/repository/org/tukaani/xz/1.9/xz-1.9.jar, file:/home/john/.m2/repository/org/lz4/lz4-java/1.8.0/lz4-java-1.8.0.jar, file:/home/john/.m2/repository/com/google/code/gson/gson/2.10.1/gson-2.10.1.jar, file:/home/john/.m2/repository/org/scijava/scijava-common/2.97.0/scijava-common-2.97.0.jar, file:/home/john/.m2/repository/org/scijava/parsington/3.1.0/parsington-3.1.0.jar, file:/home/john/.m2/repository/org/apache/commons/commons-compress/1.23.0/commons-compress-1.23.0.jar, file:/home/john/.m2/repository/org/janelia/saalfeldlab/n5-aws-s3/4.1.1/n5-aws-s3-4.1.1.jar, file:/home/john/.m2/repository/com/amazonaws/aws-java-sdk-s3/1.12.465/aws-java-sdk-s3-1.12.465.jar, file:/home/john/.m2/repository/com/amazonaws/aws-java-sdk-kms/1.12.465/aws-java-sdk-kms-1.12.465.jar, file:/home/john/.m2/repository/com/amazonaws/aws-java-sdk-core/1.12.465/aws-java-sdk-core-1.12.465.jar, file:/home/john/.m2/repository/software/amazon/ion/ion-java/1.0.2/ion-java-1.0.2.jar, file:/home/john/.m2/repository/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.14.2/jackson-dataformat-cbor-2.14.2.jar, file:/home/john/.m2/repository/joda-time/joda-time/2.12.5/joda-time-2.12.5.jar, file:/home/john/.m2/repository/com/amazonaws/jmespath-java/1.12.465/jmespath-java-1.12.465.jar, file:/home/john/.m2/repository/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar, file:/home/john/.m2/repository/org/janelia/saalfeldlab/n5-google-cloud/4.1.0/n5-google-cloud-4.1.0.jar, file:/home/john/.m2/repository/com/google/cloud/google-cloud-storage/2.22.1/google-cloud-storage-2.22.1.jar, file:/home/john/.m2/repository/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar, file:/home/john/.m2/repository/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar, file:/home/john/.m2/repository/com/google/errorprone/error_prone_annotations/2.19.0/error_prone_annotations-2.19.0.jar, file:/home/john/.m2/repository/com/google/j2objc/j2objc-annotations/2.8/j2objc-annotations-2.8.jar, file:/home/john/.m2/repository/io/opencensus/opencensus-contrib-http-util/0.31.1/opencensus-contrib-http-util-0.31.1.jar, file:/home/john/.m2/repository/com/google/http-client/google-http-client-jackson2/1.43.1/google-http-client-jackson2-1.43.1.jar, file:/home/john/.m2/repository/com/google/api-client/google-api-client/2.2.0/google-api-client-2.2.0.jar, file:/home/john/.m2/repository/commons-codec/commons-codec/1.15/commons-codec-1.15.jar, file:/home/john/.m2/repository/com/google/oauth-client/google-oauth-client/1.34.1/google-oauth-client-1.34.1.jar, file:/home/john/.m2/repository/com/google/http-client/google-http-client-apache-v2/1.43.1/google-http-client-apache-v2-1.43.1.jar, file:/home/john/.m2/repository/com/google/auto/value/auto-value-annotations/1.10.1/auto-value-annotations-1.10.1.jar, file:/home/john/.m2/repository/com/google/cloud/google-cloud-core-http/2.16.0/google-cloud-core-http-2.16.0.jar, file:/home/john/.m2/repository/com/google/http-client/google-http-client-appengine/1.43.1/google-http-client-appengine-1.43.1.jar, file:/home/john/.m2/repository/com/google/api/gax-httpjson/0.111.0/gax-httpjson-0.111.0.jar, file:/home/john/.m2/repository/com/google/cloud/google-cloud-core-grpc/2.16.0/google-cloud-core-grpc-2.16.0.jar, file:/home/john/.m2/repository/com/google/api/gax-grpc/2.26.0/gax-grpc-2.26.0.jar, file:/home/john/.m2/repository/io/grpc/grpc-alts/1.54.0/grpc-alts-1.54.0.jar, file:/home/john/.m2/repository/io/grpc/grpc-grpclb/1.54.0/grpc-grpclb-1.54.0.jar, file:/home/john/.m2/repository/org/conscrypt/conscrypt-openjdk-uber/2.5.2/conscrypt-openjdk-uber-2.5.2.jar, file:/home/john/.m2/repository/io/grpc/grpc-auth/1.54.0/grpc-auth-1.54.0.jar, file:/home/john/.m2/repository/io/grpc/grpc-protobuf/1.54.0/grpc-protobuf-1.54.0.jar, file:/home/john/.m2/repository/io/grpc/grpc-protobuf-lite/1.54.0/grpc-protobuf-lite-1.54.0.jar, file:/home/john/.m2/repository/com/google/auth/google-auth-library-credentials/1.16.1/google-auth-library-credentials-1.16.1.jar, file:/home/john/.m2/repository/com/google/auth/google-auth-library-oauth2-http/1.16.1/google-auth-library-oauth2-http-1.16.1.jar, file:/home/john/.m2/repository/com/google/api/api-common/2.9.0/api-common-2.9.0.jar, file:/home/john/.m2/repository/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar, file:/home/john/.m2/repository/io/opencensus/opencensus-api/0.31.1/opencensus-api-0.31.1.jar, file:/home/john/.m2/repository/io/grpc/grpc-context/1.55.1/grpc-context-1.55.1.jar, file:/home/john/.m2/repository/com/google/api/grpc/proto-google-iam-v1/1.12.0/proto-google-iam-v1-1.12.0.jar, file:/home/john/.m2/repository/com/google/protobuf/protobuf-java/3.23.0/protobuf-java-3.23.0.jar, file:/home/john/.m2/repository/com/google/protobuf/protobuf-java-util/3.23.0/protobuf-java-util-3.23.0.jar, file:/home/john/.m2/repository/com/google/api/grpc/proto-google-common-protos/2.17.0/proto-google-common-protos-2.17.0.jar, file:/home/john/.m2/repository/org/threeten/threetenbp/1.6.8/threetenbp-1.6.8.jar, file:/home/john/.m2/repository/com/google/api/grpc/proto-google-cloud-storage-v2/2.22.1-alpha/proto-google-cloud-storage-v2-2.22.1-alpha.jar, file:/home/john/.m2/repository/com/google/api/grpc/grpc-google-cloud-storage-v2/2.22.1-alpha/grpc-google-cloud-storage-v2-2.22.1-alpha.jar, file:/home/john/.m2/repository/com/google/api/grpc/gapic-google-cloud-storage-v2/2.22.1-alpha/gapic-google-cloud-storage-v2-2.22.1-alpha.jar, file:/home/john/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.14.2/jackson-core-2.14.2.jar, file:/home/john/.m2/repository/io/grpc/grpc-api/1.54.0/grpc-api-1.54.0.jar, file:/home/john/.m2/repository/io/grpc/grpc-netty-shaded/1.54.0/grpc-netty-shaded-1.54.0.jar, file:/home/john/.m2/repository/io/perfmark/perfmark-api/0.26.0/perfmark-api-0.26.0.jar, file:/home/john/.m2/repository/io/grpc/grpc-core/1.54.0/grpc-core-1.54.0.jar, file:/home/john/.m2/repository/com/google/android/annotations/4.1.1.4/annotations-4.1.1.4.jar, file:/home/john/.m2/repository/org/codehaus/mojo/animal-sniffer-annotations/1.23/animal-sniffer-annotations-1.23.jar, file:/home/john/.m2/repository/io/grpc/grpc-stub/1.54.0/grpc-stub-1.54.0.jar, file:/home/john/.m2/repository/io/grpc/grpc-googleapis/1.54.0/grpc-googleapis-1.54.0.jar, file:/home/john/.m2/repository/org/checkerframework/checker-qual/3.34.0/checker-qual-3.34.0.jar, file:/home/john/.m2/repository/io/grpc/grpc-xds/1.54.0/grpc-xds-1.54.0.jar, file:/home/john/.m2/repository/io/opencensus/opencensus-proto/0.2.0/opencensus-proto-0.2.0.jar, file:/home/john/.m2/repository/io/grpc/grpc-services/1.54.0/grpc-services-1.54.0.jar, file:/home/john/.m2/repository/com/google/re2j/re2j/1.7/re2j-1.7.jar, file:/home/john/.m2/repository/com/google/cloud/google-cloud-resourcemanager/1.18.0/google-cloud-resourcemanager-1.18.0.jar, file:/home/john/.m2/repository/com/google/api/grpc/proto-google-cloud-resourcemanager-v3/1.18.0/proto-google-cloud-resourcemanager-v3-1.18.0.jar, file:/home/john/.m2/repository/com/google/apis/google-api-services-cloudresourcemanager/v1-rev20230129-2.0.0/google-api-services-cloudresourcemanager-v1-rev20230129-2.0.0.jar, file:/home/john/.m2/repository/org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar, file:/home/john/.m2/repository/commons-logging/commons-logging/1.2/commons-logging-1.2.jar, file:/home/john/.m2/repository/org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar, file:/home/john/.m2/repository/org/janelia/saalfeldlab/n5-imglib2/7.0.0/n5-imglib2-7.0.0.jar, file:/home/john/.m2/repository/net/imglib2/imglib2-label-multisets/0.11.5/imglib2-label-multisets-0.11.5.jar, file:/home/john/.m2/repository/net/sf/trove4j/trove4j/3.0.3/trove4j-3.0.3.jar, file:/home/john/.m2/repository/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar, file:/home/john/.m2/repository/net/imglib2/imglib2/6.2.0/imglib2-6.2.0.jar, file:/home/john/.m2/repository/net/imglib2/imglib2-cache/1.0.0-beta-17/imglib2-cache-1.0.0-beta-17.jar, file:/home/john/.m2/repository/com/github/ben-manes/caffeine/caffeine/2.9.3/caffeine-2.9.3.jar, file:/home/john/.m2/repository/org/scijava/scijava-optional/1.0.1/scijava-optional-1.0.1.jar, file:/home/john/.m2/repository/net/imglib2/imglib2-realtransform/4.0.1/imglib2-realtransform-4.0.1.jar, file:/home/john/.m2/repository/gov/nist/math/jama/1.0.3/jama-1.0.3.jar, file:/home/john/.m2/repository/jitk/jitk-tps/3.0.3/jitk-tps-3.0.3.jar, file:/home/john/.m2/repository/com/googlecode/efficient-java-matrix-library/ejml/0.25/ejml-0.25.jar, file:/home/john/.m2/repository/org/janelia/saalfeldlab/n5-hdf5/2.2.0/n5-hdf5-2.2.0.jar, file:/home/john/.m2/repository/cisd/jhdf5/19.04.1/jhdf5-19.04.1.jar, file:/home/john/.m2/repository/cisd/base/18.09.0/base-18.09.0.jar, file:/home/john/.m2/repository/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar, file:/home/john/.m2/repository/org/janelia/saalfeldlab/n5-zarr/1.3.1/n5-zarr-1.3.1.jar, file:/home/john/dev/n5/n5-blosc/target/classes/, file:/home/john/.m2/repository/org/lasersonlab/jblosc/1.0.1/jblosc-1.0.1.jar, file:/home/john/.m2/repository/net/java/dev/jna/jna/5.13.0/jna-5.13.0.jar, file:/home/john/.m2/repository/org/janelia/n5-zstandard/1.0.2/n5-zstandard-1.0.2.jar, file:/home/john/.m2/repository/com/github/luben/zstd-jni/1.5.5-10/zstd-jni-1.5.5-10.jar, file:/home/john/.m2/repository/net/thisptr/jackson-jq/1.0.0-preview.20191208/jackson-jq-1.0.0-preview.20191208.jar, file:/home/john/.m2/repository/org/jruby/joni/joni/2.1.48/joni-2.1.48.jar, file:/home/john/.m2/repository/org/jruby/jcodings/jcodings/1.0.58/jcodings-1.0.58.jar, file:/home/john/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.14.2/jackson-databind-2.14.2.jar, file:/home/john/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.14.2/jackson-annotations-2.14.2.jar, file:/home/john/.m2/repository/se/sawano/java/alphanumeric-comparator/1.4.1/alphanumeric-comparator-1.4.1.jar, file:/home/john/.m2/repository/org/janelia/saalfeldlab/n5/3.2.0/n5-3.2.0-tests.jar, file:/home/john/.m2/repository/org/janelia/saalfeldlab/n5-zarr/1.3.1/n5-zarr-1.3.1-tests.jar, file:/home/john/.m2/repository/org/janelia/saalfeldlab/n5-aws-s3/4.1.1/n5-aws-s3-4.1.1-tests.jar, file:/home/john/.m2/repository/org/janelia/saalfeldlab/n5-google-cloud/4.1.0/n5-google-cloud-4.1.0-tests.jar, file:/home/john/.m2/repository/com/google/cloud/google-cloud-nio/0.126.14/google-cloud-nio-0.126.14.jar, file:/home/john/.m2/repository/com/google/apis/google-api-services-storage/v1-rev20230301-2.0.0/google-api-services-storage-v1-rev20230301-2.0.0.jar, file:/home/john/.m2/repository/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar, file:/home/john/.m2/repository/com/google/api/gax/2.26.0/gax-2.26.0.jar, file:/home/john/.m2/repository/com/google/cloud/google-cloud-core/2.16.0/google-cloud-core-2.16.0.jar, file:/home/john/.m2/repository/com/google/http-client/google-http-client/1.43.1/google-http-client-1.43.1.jar, file:/home/john/.m2/repository/com/google/http-client/google-http-client-gson/1.43.1/google-http-client-gson-1.43.1.jar, file:/home/john/.m2/repository/javax/inject/javax.inject/1/javax.inject-1.jar, file:/home/john/.m2/repository/org/janelia/saalfeldlab/n5-hdf5/2.2.0/n5-hdf5-2.2.0-tests.jar, file:/home/john/.m2/repository/com/googlecode/json-simple/json-simple/1.1.1/json-simple-1.1.1.jar, file:/home/john/.m2/repository/junit/junit/4.13.2/junit-4.13.2.jar, file:/home/john/.m2/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar, file:/home/john/.m2/repository/commons-io/commons-io/2.11.0/commons-io-2.11.0.jar, file:/home/john/.m2/repository/io/findify/s3mock_2.12/0.2.5/s3mock_2.12-0.2.5.jar, file:/home/john/.m2/repository/org/scala-lang/scala-library/2.12.4/scala-library-2.12.4.jar, file:/home/john/.m2/repository/com/typesafe/akka/akka-stream_2.12/2.5.11/akka-stream_2.12-2.5.11.jar, file:/home/john/.m2/repository/com/typesafe/akka/akka-actor_2.12/2.5.11/akka-actor_2.12-2.5.11.jar, file:/home/john/.m2/repository/com/typesafe/config/1.3.2/config-1.3.2.jar, file:/home/john/.m2/repository/org/scala-lang/modules/scala-java8-compat_2.12/0.8.0/scala-java8-compat_2.12-0.8.0.jar, file:/home/john/.m2/repository/com/typesafe/akka/akka-protobuf_2.12/2.5.11/akka-protobuf_2.12-2.5.11.jar, file:/home/john/.m2/repository/org/reactivestreams/reactive-streams/1.0.2/reactive-streams-1.0.2.jar, file:/home/john/.m2/repository/com/typesafe/ssl-config-core_2.12/0.2.2/ssl-config-core_2.12-0.2.2.jar, file:/home/john/.m2/repository/org/scala-lang/modules/scala-parser-combinators_2.12/1.0.4/scala-parser-combinators_2.12-1.0.4.jar, file:/home/john/.m2/repository/com/typesafe/akka/akka-http_2.12/10.1.0/akka-http_2.12-10.1.0.jar, file:/home/john/.m2/repository/com/typesafe/akka/akka-http-core_2.12/10.1.0/akka-http-core_2.12-10.1.0.jar, file:/home/john/.m2/repository/com/typesafe/akka/akka-parsing_2.12/10.1.0/akka-parsing_2.12-10.1.0.jar, file:/home/john/.m2/repository/org/scala-lang/modules/scala-xml_2.12/1.1.0/scala-xml_2.12-1.1.0.jar, file:/home/john/.m2/repository/com/github/pathikrit/better-files_2.12/3.4.0/better-files_2.12-3.4.0.jar, file:/home/john/.m2/repository/com/typesafe/scala-logging/scala-logging_2.12/3.8.0/scala-logging_2.12-3.8.0.jar, file:/home/john/.m2/repository/org/scala-lang/scala-reflect/2.12.4/scala-reflect-2.12.4.jar, file:/home/john/.m2/repository/org/iq80/leveldb/leveldb/0.10/leveldb-0.10.jar, file:/home/john/.m2/repository/org/iq80/leveldb/leveldb-api/0.10/leveldb-api-0.10.jar, file:/home/john/.m2/repository/javax/xml/bind/jaxb-api/2.2.2/jaxb-api-2.2.2.jar, file:/home/john/.m2/repository/javax/xml/stream/stax-api/1.0-2/stax-api-1.0-2.jar, file:/home/john/.m2/repository/javax/activation/activation/1.1/activation-1.1.jar])
		at com.sun.jna.Native.extractFromResourcePath(Native.java:1145)
		at com.sun.jna.NativeLibrary.loadLibrary(NativeLibrary.java:295)
		... 24 more
```
</details>

to this: 

```
Compression 'org.janelia.saalfeldlab.n5.blosc.BloscCompression' could not be registered
```

If the longer error message is desirable, we might consider logging levels.

@StephanPreibisch  @axtimwalde 