### PR TITLE
fix: add statement defining n5 datasets as leaf nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Chunked datasets can be sparse, i.e. empty chunks do not need to be stored.
 
 N5 group is not a single file but simply a directory on the file system.  Meta-data is stored as a JSON file per each group/ directory.  Tensor datasets can be chunked and chunks are stored as individual files.  This enables parallel reading and writing on a cluster.
 
-1. All directories of the file system are N5 groups.
+1. All directories of the file system are N5 groups, except for any directory descended from an N5 dataset.
 2. A JSON file `attributes.json` in a directory contains arbitrary attributes.  A group without attributes may not have an `attributes.json` file.
 3. The version of this specification is 1.0.0 and is stored in the "n5" attribute of the root group "/".
 4. A dataset is a group with the mandatory attributes:


### PR DESCRIPTION
the language of the spec permits datasets to contain sub-groups, but these configurations could easily break the basic dataset block API. Correct me if I'm wrong, but I assume the intention of the spec is to forbid datasets with sub-groups, so I added an explicit statement to this effect to the spec document. I didn't change the spec version because it wasn't clear to me whether this would be considered a breaking change or not. Happy to follow feedback on that.