### PR TITLE
fix: existsFromContainer should use the cache key for creating new cache

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/CachedGsonKeyValueN5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/CachedGsonKeyValueN5Reader.java
@@ -133,7 +133,7 @@ public interface CachedGsonKeyValueN5Reader extends GsonKeyValueN5Reader, N5Json
 
 		final String normalPathName = N5URI.normalizeGroupPath(pathName);
 		if (cacheMeta())
-			return getCache().isGroup(normalPathName, N5KeyValueReader.ATTRIBUTES_JSON);
+			return getCache().isGroup(normalPathName, null);
 		else {
 			return existsFromContainer(normalPathName, null);
 		}

--- a/src/main/java/org/janelia/saalfeldlab/n5/cache/N5JsonCache.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/cache/N5JsonCache.java
@@ -164,7 +164,7 @@ public class N5JsonCache {
 			final JsonElement uncachedAttributes) {
 
 		final N5CacheInfo cacheInfo;
-		if (container.existsFromContainer(normalPathKey, null)) {
+		if (container.existsFromContainer(normalPathKey, normalCacheKey)) {
 			cacheInfo = newCacheInfo();
 		} else {
 			cacheInfo = emptyCacheInfo;


### PR DESCRIPTION
isGroup for N5 doesn't require attributes.json