### PR TITLE
fix: assumption that the first deepListHelper result is always self

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
@@ -565,10 +565,9 @@ public interface N5Reader extends AutoCloseable {
 		final LinkedBlockingQueue<Future<String>> datasetFutures = new LinkedBlockingQueue<>();
 		deepListHelper(this, normalPathName, false, filter, executor, datasetFutures);
 
-		datasetFutures.poll().get(); // skip self
 		while (!datasetFutures.isEmpty()) {
 			final String result = datasetFutures.poll().get();
-			if (result != null)
+			if (result != null && !result.isEmpty())
 				results.add(result.substring(normalPathName.length() + groupSeparator.length()));
 		}
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Reader.java
@@ -567,7 +567,7 @@ public interface N5Reader extends AutoCloseable {
 
 		while (!datasetFutures.isEmpty()) {
 			final String result = datasetFutures.poll().get();
-			if (result != null && !result.isEmpty())
+			if (result != null && !result.equals(normalPathName))
 				results.add(result.substring(normalPathName.length() + groupSeparator.length()));
 		}
 


### PR DESCRIPTION
It seems that on some systems (e.g. github actions) the order of the deepListHelper results is not gauranteed such that the first entry is always self.

When it is not, we throw away a needed result, and later get an error as we try to process a result which *is* self, and is an empty string. This causes the substring method to throw an error, though generally it is swallowed later, and rarely seen (another problem)