### PR TITLE
More extensible list response parsers

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/CachedGsonKeyValueN5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/CachedGsonKeyValueN5Reader.java
@@ -26,7 +26,6 @@
 package org.janelia.saalfeldlab.n5;
 
 import java.lang.reflect.Type;
-import java.net.URI;
 
 import com.google.gson.JsonSyntaxException;
 import org.janelia.saalfeldlab.n5.N5Exception.N5IOException;

--- a/src/main/java/org/janelia/saalfeldlab/n5/HttpKeyValueAccess.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/HttpKeyValueAccess.java
@@ -22,6 +22,7 @@ package org.janelia.saalfeldlab.n5;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.function.TriFunction;
+import org.janelia.saalfeldlab.n5.http.ApacheListResponseParser;
 import org.janelia.saalfeldlab.n5.http.CandidateListResponseParser;
 import org.janelia.saalfeldlab.n5.http.ListResponseParser;
 import org.janelia.saalfeldlab.n5.http.MicrosoftListResponseParser;
@@ -60,12 +61,14 @@ public class HttpKeyValueAccess implements KeyValueAccess {
 	private CandidateListResponseParser candidateParsers = new CandidateListResponseParser(
 			new ListResponseParser[] {
 					MicrosoftListResponseParser.parser(),
+					ApacheListResponseParser.parser(),
 					PythonListResponseParser.parser()
 			});
 
 	private CandidateListResponseParser candidateDirectoryParsers = new CandidateListResponseParser(
 			new ListResponseParser[] {
 					MicrosoftListResponseParser.directoryParser(),
+					ApacheListResponseParser.directoryParser(),
 					PythonListResponseParser.directoryParser()
 			});
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/HttpKeyValueAccess.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/HttpKeyValueAccess.java
@@ -22,11 +22,7 @@ package org.janelia.saalfeldlab.n5;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.function.TriFunction;
-import org.janelia.saalfeldlab.n5.http.ApacheListResponseParser;
-import org.janelia.saalfeldlab.n5.http.CandidateListResponseParser;
 import org.janelia.saalfeldlab.n5.http.ListResponseParser;
-import org.janelia.saalfeldlab.n5.http.MicrosoftListResponseParser;
-import org.janelia.saalfeldlab.n5.http.PythonListResponseParser;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -55,22 +51,8 @@ public class HttpKeyValueAccess implements KeyValueAccess {
 	private int readTimeoutMilliseconds;
 	private int connectionTimeoutMilliseconds;
 
-	private ListResponseParser listResponseParser;
-	private ListResponseParser listDirectoryResponseParser;
-
-	private CandidateListResponseParser candidateParsers = new CandidateListResponseParser(
-			new ListResponseParser[] {
-					MicrosoftListResponseParser.parser(),
-					ApacheListResponseParser.parser(),
-					PythonListResponseParser.parser()
-			});
-
-	private CandidateListResponseParser candidateDirectoryParsers = new CandidateListResponseParser(
-			new ListResponseParser[] {
-					MicrosoftListResponseParser.directoryParser(),
-					ApacheListResponseParser.directoryParser(),
-					PythonListResponseParser.directoryParser()
-			});
+	private ListResponseParser listResponseParser = ListResponseParser.defaultListParser();
+	private ListResponseParser listDirectoryResponseParser = ListResponseParser.defaultDirectoryListParser();
 
 	/**
 	 * Opens an {@link HttpKeyValueAccess}
@@ -257,16 +239,7 @@ public class HttpKeyValueAccess implements KeyValueAccess {
 	@Override
 	public String[] listDirectories(final String normalPath) throws IOException {
 
-		if (listDirectoryResponseParser != null)
-			return queryListEntries(normalPath, listDirectoryResponseParser, true);
-		else
-		{
-			final String[] result = queryListEntries(normalPath, candidateDirectoryParsers, true);
-			if (candidateDirectoryParsers.successfulParser() != null)
-				listDirectoryResponseParser = candidateDirectoryParsers.successfulParser();
-
-			return result;
-		}
+		return queryListEntries(normalPath, listDirectoryResponseParser, true);
 	}
 
 	/**
@@ -285,16 +258,7 @@ public class HttpKeyValueAccess implements KeyValueAccess {
 	@Override
 	public String[] list(final String normalPath) throws IOException {
 
-		if (listResponseParser != null)
-			return queryListEntries(normalPath, listResponseParser, true);
-		else
-		{
-			final String[] result = queryListEntries(normalPath, candidateParsers, true);
-			if (candidateParsers.successfulParser() != null)
-				listResponseParser = candidateParsers.successfulParser();
-
-			return result;
-		}
+		return queryListEntries(normalPath, listResponseParser, true);
 	}
 
 	private String[] queryListEntries(String normalPath, ListResponseParser parser, boolean allowRedirect) {

--- a/src/main/java/org/janelia/saalfeldlab/n5/cache/N5JsonCache.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/cache/N5JsonCache.java
@@ -2,7 +2,7 @@ package org.janelia.saalfeldlab.n5.cache;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 
 import org.janelia.saalfeldlab.n5.N5Exception;
 
@@ -29,7 +29,7 @@ public class N5JsonCache {
 	protected static class N5CacheInfo {
 
 		protected final HashMap<String, JsonElement> attributesCache = new HashMap<>();
-		protected HashSet<String> children = null;
+		protected LinkedHashSet<String> children = null;
 		protected boolean isDataset = false;
 		protected boolean isGroup = false;
 
@@ -204,7 +204,7 @@ public class N5JsonCache {
 	private void addChild(final N5CacheInfo cacheInfo, final String normalPathKey) {
 
 		if (cacheInfo.children == null)
-			cacheInfo.children = new HashSet<>();
+			cacheInfo.children = new LinkedHashSet<>();
 
 		final String[] children = container.listFromContainer(normalPathKey);
 		Collections.addAll(cacheInfo.children, children);
@@ -338,7 +338,7 @@ public class N5JsonCache {
 			return;
 
 		if (cacheInfo.children == null)
-			cacheInfo.children = new HashSet<>();
+			cacheInfo.children = new LinkedHashSet<>();
 
 		cacheInfo.children.add(child);
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/http/ApacheListResponseParser.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/http/ApacheListResponseParser.java
@@ -5,7 +5,7 @@ import java.util.regex.Pattern;
 /**
  * {@link ListResponseParser}s for <a href="https://httpd.apache.org/">Apache HTTP Servers</a>.
  */
-public abstract class ApacheListResponseParser extends PatternListResponseParser {
+abstract class ApacheListResponseParser extends PatternListResponseParser {
 
 	private static final Pattern LIST_ENTRY = Pattern.compile("alt=\"\\[(\\s*|DIR)\\]\".*href=[^>]+>(?<entry>[^<]+)");
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/http/ApacheListResponseParser.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/http/ApacheListResponseParser.java
@@ -1,0 +1,45 @@
+package org.janelia.saalfeldlab.n5.http;
+
+import java.util.regex.Pattern;
+
+/**
+ * {@link ListResponseParser}s for <a href="https://httpd.apache.org/">Apache HTTP Servers</a>.
+ */
+public abstract class ApacheListResponseParser extends PatternListResponseParser {
+
+	private static final Pattern LIST_ENTRY = Pattern.compile("alt=\"\\[(\\s*|DIR)\\]\".*href=[^>]+>(?<entry>[^<]+)");
+
+	private static final Pattern LIST_DIR_ENTRY = Pattern.compile("alt=\"\\[DIR\\]\".*href=[^>]+>(?<entry>[^<]+)");
+
+	ApacheListResponseParser(Pattern pattern) {
+
+		super(pattern);
+	}
+
+	static class ListDirectories extends ApacheListResponseParser {
+
+		public ListDirectories() {
+
+			super(LIST_DIR_ENTRY);
+		}
+	}
+
+	static class ListAll extends ApacheListResponseParser {
+
+		public ListAll() {
+
+			super(LIST_ENTRY);
+		}
+	}
+
+	public static ListResponseParser directoryParser() {
+
+		return new ListDirectories();
+	}
+
+	public static ListResponseParser parser() {
+
+		return new ListAll();
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/n5/http/CandidateListResponseParser.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/http/CandidateListResponseParser.java
@@ -1,0 +1,35 @@
+package org.janelia.saalfeldlab.n5.http;
+
+public class CandidateListResponseParser implements ListResponseParser {
+
+	private ListResponseParser[] candidateParsers;
+
+	private ListResponseParser successfulParser;
+
+	public CandidateListResponseParser(ListResponseParser[] candidateParsers) {
+
+		this.candidateParsers = candidateParsers;
+	}
+
+	@Override
+	public String[] parseListResponse(String response) {
+
+		String[] result = new String[0];
+		for (ListResponseParser parser : candidateParsers) {
+
+			result = parser.parseListResponse(response);
+			if (result.length > 1) {
+				successfulParser = parser;
+				return result;
+			}
+		}
+
+		return result;
+	}
+
+	public ListResponseParser successfulParser() {
+
+		return successfulParser;
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/n5/http/CandidateListResponseParser.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/http/CandidateListResponseParser.java
@@ -1,18 +1,21 @@
 package org.janelia.saalfeldlab.n5.http;
 
-public class CandidateListResponseParser implements ListResponseParser {
+class CandidateListResponseParser implements ListResponseParser {
 
 	private ListResponseParser[] candidateParsers;
 
 	private ListResponseParser successfulParser;
 
-	public CandidateListResponseParser(ListResponseParser[] candidateParsers) {
+	CandidateListResponseParser(ListResponseParser[] candidateParsers) {
 
 		this.candidateParsers = candidateParsers;
 	}
 
 	@Override
 	public String[] parseListResponse(String response) {
+
+		if (successfulParser != null)
+			return successfulParser.parseListResponse(response);
 
 		String[] result = new String[0];
 		for (ListResponseParser parser : candidateParsers) {

--- a/src/main/java/org/janelia/saalfeldlab/n5/http/ListResponseParser.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/http/ListResponseParser.java
@@ -1,8 +1,5 @@
 package org.janelia.saalfeldlab.n5.http;
 
-/**
- * A
- */
 public interface ListResponseParser {
 
 	/**
@@ -14,4 +11,25 @@ public interface ListResponseParser {
 	 * @return the list elements it contains
 	 */
 	String[] parseListResponse(final String response);
+
+	public static ListResponseParser defaultListParser() {
+
+		return new CandidateListResponseParser(
+				new ListResponseParser[]{
+						MicrosoftListResponseParser.parser(),
+						ApacheListResponseParser.parser(),
+						PythonListResponseParser.parser()
+				});
+	}
+
+	public static ListResponseParser defaultDirectoryListParser() {
+
+		return new CandidateListResponseParser(
+				new ListResponseParser[]{
+						MicrosoftListResponseParser.directoryParser(),
+						ApacheListResponseParser.directoryParser(),
+						PythonListResponseParser.directoryParser()
+				});
+	}
+
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/http/ListResponseParser.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/http/ListResponseParser.java
@@ -1,0 +1,17 @@
+package org.janelia.saalfeldlab.n5.http;
+
+/**
+ * A
+ */
+public interface ListResponseParser {
+
+	/**
+	 * Parse a String response for a list call, and return the results as a
+	 * String array.
+	 *
+	 * @param response
+	 *            an (http) response
+	 * @return the list elements it contains
+	 */
+	String[] parseListResponse(final String response);
+}

--- a/src/main/java/org/janelia/saalfeldlab/n5/http/MicrosoftListResponseParser.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/http/MicrosoftListResponseParser.java
@@ -1,0 +1,45 @@
+package org.janelia.saalfeldlab.n5.http;
+
+import java.util.regex.Pattern;
+
+/**
+ * {@link ListResponseParser}s for <a href="https://www.iis.net/">Microsoft-IIS Servers</a>.
+ */
+public abstract class MicrosoftListResponseParser extends PatternListResponseParser {
+
+	private static final Pattern LIST_ENTRY = Pattern.compile( "HREF=[^>]+>(?!\\[To Parent Directory])(?<entry>[^<]+)");
+
+	private static final Pattern LIST_DIR_ENTRY = Pattern.compile( "&lt;dir&gt;[^H]+HREF=[^>]+>(?!\\[To Parent Directory])(?<entry>[^<]+)");
+
+	MicrosoftListResponseParser(Pattern pattern) {
+
+		super(pattern);
+	}
+
+	static class ListDirectories extends MicrosoftListResponseParser {
+
+		public ListDirectories() {
+
+			super(LIST_DIR_ENTRY);
+		}
+	}
+
+	static class ListAll extends MicrosoftListResponseParser {
+
+		public ListAll() {
+
+			super(LIST_ENTRY);
+		}
+	}
+
+	public static ListResponseParser directoryParser() {
+
+		return new ListDirectories();
+	}
+
+	public static ListResponseParser parser() {
+
+		return new ListAll();
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/n5/http/MicrosoftListResponseParser.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/http/MicrosoftListResponseParser.java
@@ -5,7 +5,7 @@ import java.util.regex.Pattern;
 /**
  * {@link ListResponseParser}s for <a href="https://www.iis.net/">Microsoft-IIS Servers</a>.
  */
-public abstract class MicrosoftListResponseParser extends PatternListResponseParser {
+abstract class MicrosoftListResponseParser extends PatternListResponseParser {
 
 	private static final Pattern LIST_ENTRY = Pattern.compile( "HREF=[^>]+>(?!\\[To Parent Directory])(?<entry>[^<]+)");
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/http/PatternListResponseParser.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/http/PatternListResponseParser.java
@@ -11,7 +11,7 @@ import java.util.regex.Pattern;
  * This implementation of parseListResponse returns all the groups named "entry"
  * for all matches of the given pattern.
  */
-public class PatternListResponseParser implements ListResponseParser {
+class PatternListResponseParser implements ListResponseParser {
 
 	protected Pattern pattern;
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/http/PatternListResponseParser.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/http/PatternListResponseParser.java
@@ -1,0 +1,34 @@
+package org.janelia.saalfeldlab.n5.http;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A {@link ListResponseParser} that uses a {@link Pattern}.
+ *
+ * This implementation of parseListResponse returns all the groups named "entry"
+ * for all matches of the given pattern.
+ */
+public class PatternListResponseParser implements ListResponseParser {
+
+	protected Pattern pattern;
+
+	public PatternListResponseParser(Pattern pattern) {
+
+		this.pattern = pattern;
+	}
+
+	@Override
+	public String[] parseListResponse(final String response) {
+
+		final Matcher matcher = pattern.matcher(response);
+		final List<String> matches = new ArrayList<>();
+		while (matcher.find()) {
+			matches.add(matcher.group("entry"));
+		}
+		return matches.toArray(new String[0]);
+	}
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/n5/http/PythonListResponseParser.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/http/PythonListResponseParser.java
@@ -5,7 +5,7 @@ import java.util.regex.Pattern;
 /**
  * {@link ListResponseParser}s for <a href="https://docs.python.org/3/library/http.server.html">Python's SimpleHTTP Server</a>.
  */
-public abstract class PythonListResponseParser extends PatternListResponseParser {
+abstract class PythonListResponseParser extends PatternListResponseParser {
 
 	private static final Pattern LIST_ENTRY = Pattern.compile("href=\"[^\"]+\">(?<entry>[^<]+)");
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/http/PythonListResponseParser.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/http/PythonListResponseParser.java
@@ -1,0 +1,45 @@
+package org.janelia.saalfeldlab.n5.http;
+
+import java.util.regex.Pattern;
+
+/**
+ * {@link ListResponseParser}s for <a href="https://docs.python.org/3/library/http.server.html">Python's SimpleHTTP Server</a>.
+ */
+public abstract class PythonListResponseParser extends PatternListResponseParser {
+
+	private static final Pattern LIST_ENTRY = Pattern.compile("href=\"[^\"]+\">(?<entry>[^<]+)");
+
+	private static final Pattern LIST_DIR_ENTRY = Pattern.compile("href=\"[^\"]+\">(?<entry>[^<]+)/");
+
+	PythonListResponseParser(Pattern pattern) {
+
+		super(pattern);
+	}
+
+	static class ListDirectories extends PythonListResponseParser {
+
+		public ListDirectories() {
+
+			super(LIST_DIR_ENTRY);
+		}
+	}
+
+	static class ListAll extends PythonListResponseParser {
+
+		public ListAll() {
+
+			super(LIST_ENTRY);
+		}
+	}
+
+	public static ListResponseParser directoryParser() {
+
+		return new ListDirectories();
+	}
+
+	public static ListResponseParser parser() {
+
+		return new ListAll();
+	}
+
+}

--- a/src/test/java/org/janelia/saalfeldlab/n5/N5CachedFSTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/N5CachedFSTest.java
@@ -14,6 +14,11 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.Test;
 
@@ -417,7 +422,8 @@ public class N5CachedFSTest extends N5FSTest {
 		assertEquals(++expectedAttributeCount, n5.getAttrCallCount());
 		assertEquals(expectedWriteAttributeCount, n5.getWriteAttrCallCount());
 
-		assertArrayEquals(new String[] {"a", "b", "c"}, n5.list("a")); // call list
+		final Set<String> listSet = Arrays.stream(n5.list("a")).collect(Collectors.toSet());
+		assertEquals(Stream.of("a", "b", "c").collect(Collectors.toSet()), listSet);
 		assertEquals(expectedGroupCount, n5.getGroupCallCount());
 		assertEquals(expectedDatasetCount, n5.getDatasetCallCount());
 		assertEquals(expectedAttributeCount, n5.getAttrCallCount());


### PR DESCRIPTION
Adds an interface `ListResponseParser` and two implementations:

* Python's SimpleHTTP
* Microsoft's IIS

Also updates HttpKeyValue access so that, on the first list call, a collection of known implementations are used,
and the first successful one is stored.

@cmhulbert 