### PR TITLE
Fix/uri resolve java8

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/FileSystemKeyValueAccess.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/FileSystemKeyValueAccess.java
@@ -325,6 +325,8 @@ public class FileSystemKeyValueAccess implements KeyValueAccess {
 		else
 			composedPath = Paths.get(uri.toString());
 		for (String component : components) {
+			if (component == null || component.isEmpty())
+				continue;
 			composedPath = composedPath.resolve(component);
 		}
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/KeyValueAccess.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/KeyValueAccess.java
@@ -81,7 +81,7 @@ public interface KeyValueAccess {
 	public default String compose(final URI uri, final String... components) {
 
 		int firstNonEmptyIdx = 0;
-		while (firstNonEmptyIdx < components.length && components[firstNonEmptyIdx].isEmpty()) {
+		while (firstNonEmptyIdx < components.length && (components[firstNonEmptyIdx] == null || components[firstNonEmptyIdx].isEmpty())) {
 			firstNonEmptyIdx++;
 		}
 
@@ -106,9 +106,7 @@ public interface KeyValueAccess {
 		URI composedUri = uri;
 		for (int i = 0; i < allComponents.length; i++) {
 			final String component = allComponents[i];
-			if (component == null || component.isEmpty())
-				continue;
-			else if (component.endsWith("/") || i == allComponents.length - 1)
+			if (component.endsWith("/") || i == allComponents.length - 1)
 				composedUri = composedUri.resolve(N5URI.encodeAsUriPath(component));
 			else
 				composedUri = composedUri.resolve(N5URI.encodeAsUriPath(component + "/"));

--- a/src/main/java/org/janelia/saalfeldlab/n5/KeyValueAccess.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/KeyValueAccess.java
@@ -106,7 +106,9 @@ public interface KeyValueAccess {
 		URI composedUri = uri;
 		for (int i = 0; i < allComponents.length; i++) {
 			final String component = allComponents[i];
-			if (component.endsWith("/") || i == allComponents.length - 1)
+			if (component == null || component.isEmpty())
+				continue;
+			else if (component.endsWith("/") || i == allComponents.length - 1)
 				composedUri = composedUri.resolve(N5URI.encodeAsUriPath(component));
 			else
 				composedUri = composedUri.resolve(N5URI.encodeAsUriPath(component + "/"));

--- a/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/AbstractN5Test.java
@@ -45,6 +45,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.function.Predicate;
@@ -1074,12 +1075,16 @@ public abstract class AbstractN5Test {
 	@Test
 	public void testReaderCreation() throws IOException, URISyntaxException {
 
-		final String location;
-		N5Writer removeMe = null;
-		try (N5Writer writer = createN5Writer()) {
-			removeMe = writer;
-			location = writer.getURI().toString();
+		// non-existent location should fail
+		final String location = tempN5Location() + "-" + UUID.randomUUID();
+		assertThrows("Non-existent location throws error", N5Exception.N5IOException.class,
+				() -> {
+					try (N5Reader test = createN5Reader(location)) {
+						test.list("/");
+					}
+				});
 
+		try (N5Writer writer = createTempN5Writer(location)) {
 			try (N5Reader n5r = createN5Reader(location)) {
 				assertNotNull(n5r);
 			}
@@ -1107,17 +1112,7 @@ public abstract class AbstractN5Test {
 					 /*Only try with resource to ensure `close()` is called.*/
 				}
 			});
-		} finally {
-			removeMe.remove();
 		}
-
-		// non-existent location should fail
-		assertThrows("Non-existent location throws error", N5Exception.N5IOException.class,
-				() -> {
-					try (N5Reader test = createN5Reader(location)) {
-						test.list("/");
-					}
-				});
 	}
 
 	@Test

--- a/src/test/java/org/janelia/saalfeldlab/n5/N5CachedFSTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/N5CachedFSTest.java
@@ -15,6 +15,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -422,8 +423,8 @@ public class N5CachedFSTest extends N5FSTest {
 		assertEquals(++expectedAttributeCount, n5.getAttrCallCount());
 		assertEquals(expectedWriteAttributeCount, n5.getWriteAttrCallCount());
 
-		final Set<String> listSet = Arrays.stream(n5.list("a")).collect(Collectors.toSet());
-		assertEquals(Stream.of("a", "b", "c").collect(Collectors.toSet()), listSet);
+		final Set<String> abcListSet = Arrays.stream(n5.list("a")).collect(Collectors.toSet());
+		assertEquals(Stream.of("a", "b", "c").collect(Collectors.toSet()), abcListSet);
 		assertEquals(expectedGroupCount, n5.getGroupCallCount());
 		assertEquals(expectedDatasetCount, n5.getDatasetCallCount());
 		assertEquals(expectedAttributeCount, n5.getAttrCallCount());
@@ -432,7 +433,8 @@ public class N5CachedFSTest extends N5FSTest {
 
 		// remove a
 		n5.remove("a/a");
-		assertArrayEquals(new String[] {"b", "c"}, n5.list("a")); // call list
+		final Set<String> bc = Arrays.stream(n5.list("a")).collect(Collectors.toSet());
+		assertEquals(Stream.of("b", "c").collect(Collectors.toSet()), bc);
 		assertEquals(expectedExistCount, n5.getExistCallCount());
 		assertEquals(expectedGroupCount, n5.getGroupCallCount());
 		assertEquals(expectedDatasetCount, n5.getDatasetCallCount());

--- a/src/test/java/org/janelia/saalfeldlab/n5/kva/AbstractKeyValueAccessTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/kva/AbstractKeyValueAccessTest.java
@@ -163,6 +163,12 @@ public abstract class AbstractKeyValueAccessTest {
 
 		final String firstComponentEmptySecondLeadingSlash = URI.create(kva.compose(uriWithPath, "", "/bar", "baz")).getPath();
 		assertEquals("Non-empty Path, first components slash only", "/bar/baz", firstComponentEmptySecondLeadingSlash);
+
+		final String innerNullEmptyComponents = URI.create(kva.compose(uriWithPath, "bar", null, "", "baz")).getPath();
+		assertEquals("Non-empty Path, null and empty inner components", "/foo/bar/baz", innerNullEmptyComponents);
+
+		final String innerNullEmptyComponentsLeadingSlash = URI.create(kva.compose(uriWithPath, "/bar", null, "", "baz")).getPath();
+		assertEquals("Non-empty Path, null and empty inner components", "/bar/baz", innerNullEmptyComponentsLeadingSlash);
 	}
 
 	@Test
@@ -187,6 +193,12 @@ public abstract class AbstractKeyValueAccessTest {
 
 		final String firstComponentEmptySecondLeadingSlash = URI.create(kva.compose(uriWithSlashRoot, "", "/bar", "baz")).getPath();
 		assertEquals("Root (/) Path, first components slash only", "/bar/baz", firstComponentEmptySecondLeadingSlash);
+
+		final String innerNullEmptyComponents = URI.create(kva.compose(uriWithSlashRoot, "bar", null, "", "baz")).getPath();
+		assertEquals("Non-empty Path, null and empty inner components", "/bar/baz", innerNullEmptyComponents);
+
+		final String innerNullEmptyComponentsLeadingSlash = URI.create(kva.compose(uriWithSlashRoot, "/bar", null, "", "baz")).getPath();
+		assertEquals("Non-empty Path, null and empty inner components", "/bar/baz", innerNullEmptyComponentsLeadingSlash);
 	}
 
 	@Test
@@ -211,6 +223,12 @@ public abstract class AbstractKeyValueAccessTest {
 
 		final String firstComponentEmptySecondLeadingSlash = URI.create(kva.compose(uriWithEmptyRoot, "", "/bar", "baz")).getPath();
 		assertEquals("Empty Path, first components slash only", "/bar/baz", firstComponentEmptySecondLeadingSlash);
+
+		final String innerNullEmptyComponents = URI.create(kva.compose(uriWithEmptyRoot, "bar", null, "", "baz")).getPath();
+		assertEquals("Non-empty Path, null and empty inner components", "/bar/baz", innerNullEmptyComponents);
+
+		final String innerNullEmptyComponentsLeadingSlash = URI.create(kva.compose(uriWithEmptyRoot, "/bar", null, "", "baz")).getPath();
+		assertEquals("Non-empty Path, null and empty inner components", "/bar/baz", innerNullEmptyComponentsLeadingSlash);
 	}
 
 	public URI setUriPath(final URI uri, final String path) {

--- a/src/test/java/org/janelia/saalfeldlab/n5/kva/AbstractKeyValueAccessTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/kva/AbstractKeyValueAccessTest.java
@@ -143,21 +143,74 @@ public abstract class AbstractKeyValueAccessTest {
 	@Test
 	public void testCompose() {
 
-		testComposeAtLocation(tempUri());
+		final URI uri = tempUri();
+		testComposeAtLocation(uri);
+
+		final KeyValueAccess kva = newKeyValueAccess();
+		final URI uriWithPath = setUriPath(uri, "/foo");
+		assertEquals("Non-empty Path", "/foo", uriWithPath.getPath());
+		final String typicalComponents = URI.create(kva.compose(uriWithPath, "bar", "baz")).getPath();
+		assertEquals("Non-empty Path, no empty or slash in components", "/foo/bar/baz", typicalComponents);
+
+		final String firstComponentLeadingSlash = URI.create(kva.compose(uriWithPath, "/bar", "baz")).getPath();
+		assertEquals("Non-empty Path, first components leading slash", "/bar/baz", firstComponentLeadingSlash);
+
+		final String firstComponentSlashOnly = URI.create(kva.compose(uriWithPath, "/", "bar", "baz")).getPath();
+		assertEquals("Non-empty Path, first components slash only", "/bar/baz", firstComponentSlashOnly);
+
+		final String firstComponentEmpty = URI.create(kva.compose(uriWithPath, "", "bar", "baz")).getPath();
+		assertEquals("Non-empty Path, first components slash only", "/foo/bar/baz", firstComponentEmpty);
+
+		final String firstComponentEmptySecondLeadingSlash = URI.create(kva.compose(uriWithPath, "", "/bar", "baz")).getPath();
+		assertEquals("Non-empty Path, first components slash only", "/bar/baz", firstComponentEmptySecondLeadingSlash);
 	}
 
 	@Test
 	public void testComposeWithPathSlash() {
 
 		final URI uriWithSlashRoot = setUriPath(tempUri(), "/");
+		assertEquals("Root (/) Path", "/", uriWithSlashRoot.getPath());
 		testComposeAtLocation(uriWithSlashRoot);
+
+		final KeyValueAccess kva = newKeyValueAccess();
+		final String typicalComponents = URI.create(kva.compose(uriWithSlashRoot, "bar", "baz")).getPath();
+		assertEquals("Root (/) Path, no empty or slash in components", "/bar/baz", typicalComponents);
+
+		final String firstComponentLeadingSlash = URI.create(kva.compose(uriWithSlashRoot, "/bar", "baz")).getPath();
+		assertEquals("Root (/) Path, first components leading slash", "/bar/baz", firstComponentLeadingSlash);
+
+		final String firstComponentSlashOnly = URI.create(kva.compose(uriWithSlashRoot, "/", "bar", "baz")).getPath();
+		assertEquals("Root (/) Path, first components slash only", "/bar/baz", firstComponentSlashOnly);
+
+		final String firstComponentEmpty = URI.create(kva.compose(uriWithSlashRoot, "", "bar", "baz")).getPath();
+		assertEquals("Root (/) Path, first components slash only", "/bar/baz", firstComponentEmpty);
+
+		final String firstComponentEmptySecondLeadingSlash = URI.create(kva.compose(uriWithSlashRoot, "", "/bar", "baz")).getPath();
+		assertEquals("Root (/) Path, first components slash only", "/bar/baz", firstComponentEmptySecondLeadingSlash);
 	}
 
 	@Test
 	public void testComposeWithPathEmpty() {
 
 		final URI uriWithEmptyRoot = setUriPath(tempUri(), "");
+		assertEquals("Empty Path", "", uriWithEmptyRoot.getPath());
 		testComposeAtLocation(uriWithEmptyRoot);
+
+		final KeyValueAccess kva = newKeyValueAccess();
+		final String typicalComponents = URI.create(kva.compose(uriWithEmptyRoot, "bar", "baz")).getPath();
+		assertEquals("Empty Path, no empty or slash in components", "/bar/baz", typicalComponents);
+
+		final String firstComponentLeadingSlash = URI.create(kva.compose(uriWithEmptyRoot, "/bar", "baz")).getPath();
+		assertEquals("Empty Path, first components leading slash", "/bar/baz", firstComponentLeadingSlash);
+
+		final String firstComponentSlashOnly = URI.create(kva.compose(uriWithEmptyRoot, "/", "bar", "baz")).getPath();
+		assertEquals("Empty Path, first components slash only", "/bar/baz", firstComponentSlashOnly);
+
+		final String firstComponentEmpty = URI.create(kva.compose(uriWithEmptyRoot, "", "bar", "baz")).getPath();
+		assertEquals("Empty Path, first components slash only", "/bar/baz", firstComponentEmpty);
+
+		final String firstComponentEmptySecondLeadingSlash = URI.create(kva.compose(uriWithEmptyRoot, "", "/bar", "baz")).getPath();
+		assertEquals("Empty Path, first components slash only", "/bar/baz", firstComponentEmptySecondLeadingSlash);
 	}
 
 	public URI setUriPath(final URI uri, final String path) {

--- a/src/test/java/org/janelia/saalfeldlab/n5/kva/AbstractKeyValueAccessTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/kva/AbstractKeyValueAccessTest.java
@@ -116,7 +116,6 @@ public abstract class AbstractKeyValueAccessTest {
 			final String stringUriFromComponents = access.compose(baseUri, components);
 			final URI uriFromComponents = N5URI.getAsUri(stringUriFromComponents);
 			assertEquals("Failure at Index " + i, testUris[i], uriFromComponents);
-			System.out.println(uriFromComponents.toString());
 		}
 	}
 
@@ -149,25 +148,25 @@ public abstract class AbstractKeyValueAccessTest {
 		final KeyValueAccess kva = newKeyValueAccess();
 		final URI uriWithPath = setUriPath(uri, "/foo");
 		assertEquals("Non-empty Path", "/foo", uriWithPath.getPath());
-		final String typicalComponents = URI.create(kva.compose(uriWithPath, "bar", "baz")).getPath();
+		final String typicalComponents = N5URI.getAsUri(kva.compose(uriWithPath, "bar", "baz")).getPath();
 		assertEquals("Non-empty Path, no empty or slash in components", "/foo/bar/baz", typicalComponents);
 
-		final String firstComponentLeadingSlash = URI.create(kva.compose(uriWithPath, "/bar", "baz")).getPath();
+		final String firstComponentLeadingSlash = N5URI.getAsUri(kva.compose(uriWithPath, "/bar", "baz")).getPath();
 		assertEquals("Non-empty Path, first components leading slash", "/bar/baz", firstComponentLeadingSlash);
 
-		final String firstComponentSlashOnly = URI.create(kva.compose(uriWithPath, "/", "bar", "baz")).getPath();
+		final String firstComponentSlashOnly = N5URI.getAsUri(kva.compose(uriWithPath, "/", "bar", "baz")).getPath();
 		assertEquals("Non-empty Path, first components slash only", "/bar/baz", firstComponentSlashOnly);
 
-		final String firstComponentEmpty = URI.create(kva.compose(uriWithPath, "", "bar", "baz")).getPath();
+		final String firstComponentEmpty = N5URI.getAsUri(kva.compose(uriWithPath, "", "bar", "baz")).getPath();
 		assertEquals("Non-empty Path, first components slash only", "/foo/bar/baz", firstComponentEmpty);
 
-		final String firstComponentEmptySecondLeadingSlash = URI.create(kva.compose(uriWithPath, "", "/bar", "baz")).getPath();
+		final String firstComponentEmptySecondLeadingSlash = N5URI.getAsUri(kva.compose(uriWithPath, "", "/bar", "baz")).getPath();
 		assertEquals("Non-empty Path, first components slash only", "/bar/baz", firstComponentEmptySecondLeadingSlash);
 
-		final String innerNullEmptyComponents = URI.create(kva.compose(uriWithPath, "bar", null, "", "baz")).getPath();
+		final String innerNullEmptyComponents = N5URI.getAsUri(kva.compose(uriWithPath, "bar", null, "", "baz")).getPath();
 		assertEquals("Non-empty Path, null and empty inner components", "/foo/bar/baz", innerNullEmptyComponents);
 
-		final String innerNullEmptyComponentsLeadingSlash = URI.create(kva.compose(uriWithPath, "/bar", null, "", "baz")).getPath();
+		final String innerNullEmptyComponentsLeadingSlash = N5URI.getAsUri(kva.compose(uriWithPath, "/bar", null, "", "baz")).getPath();
 		assertEquals("Non-empty Path, null and empty inner components", "/bar/baz", innerNullEmptyComponentsLeadingSlash);
 	}
 
@@ -179,25 +178,25 @@ public abstract class AbstractKeyValueAccessTest {
 		testComposeAtLocation(uriWithSlashRoot);
 
 		final KeyValueAccess kva = newKeyValueAccess();
-		final String typicalComponents = URI.create(kva.compose(uriWithSlashRoot, "bar", "baz")).getPath();
+		final String typicalComponents = N5URI.getAsUri(kva.compose(uriWithSlashRoot, "bar", "baz")).getPath();
 		assertEquals("Root (/) Path, no empty or slash in components", "/bar/baz", typicalComponents);
 
-		final String firstComponentLeadingSlash = URI.create(kva.compose(uriWithSlashRoot, "/bar", "baz")).getPath();
+		final String firstComponentLeadingSlash = N5URI.getAsUri(kva.compose(uriWithSlashRoot, "/bar", "baz")).getPath();
 		assertEquals("Root (/) Path, first components leading slash", "/bar/baz", firstComponentLeadingSlash);
 
-		final String firstComponentSlashOnly = URI.create(kva.compose(uriWithSlashRoot, "/", "bar", "baz")).getPath();
+		final String firstComponentSlashOnly = N5URI.getAsUri(kva.compose(uriWithSlashRoot, "/", "bar", "baz")).getPath();
 		assertEquals("Root (/) Path, first components slash only", "/bar/baz", firstComponentSlashOnly);
 
-		final String firstComponentEmpty = URI.create(kva.compose(uriWithSlashRoot, "", "bar", "baz")).getPath();
+		final String firstComponentEmpty = N5URI.getAsUri(kva.compose(uriWithSlashRoot, "", "bar", "baz")).getPath();
 		assertEquals("Root (/) Path, first components slash only", "/bar/baz", firstComponentEmpty);
 
-		final String firstComponentEmptySecondLeadingSlash = URI.create(kva.compose(uriWithSlashRoot, "", "/bar", "baz")).getPath();
+		final String firstComponentEmptySecondLeadingSlash = N5URI.getAsUri(kva.compose(uriWithSlashRoot, "", "/bar", "baz")).getPath();
 		assertEquals("Root (/) Path, first components slash only", "/bar/baz", firstComponentEmptySecondLeadingSlash);
 
-		final String innerNullEmptyComponents = URI.create(kva.compose(uriWithSlashRoot, "bar", null, "", "baz")).getPath();
+		final String innerNullEmptyComponents = N5URI.getAsUri(kva.compose(uriWithSlashRoot, "bar", null, "", "baz")).getPath();
 		assertEquals("Non-empty Path, null and empty inner components", "/bar/baz", innerNullEmptyComponents);
 
-		final String innerNullEmptyComponentsLeadingSlash = URI.create(kva.compose(uriWithSlashRoot, "/bar", null, "", "baz")).getPath();
+		final String innerNullEmptyComponentsLeadingSlash = N5URI.getAsUri(kva.compose(uriWithSlashRoot, "/bar", null, "", "baz")).getPath();
 		assertEquals("Non-empty Path, null and empty inner components", "/bar/baz", innerNullEmptyComponentsLeadingSlash);
 	}
 
@@ -209,25 +208,25 @@ public abstract class AbstractKeyValueAccessTest {
 		testComposeAtLocation(uriWithEmptyRoot);
 
 		final KeyValueAccess kva = newKeyValueAccess();
-		final String typicalComponents = URI.create(kva.compose(uriWithEmptyRoot, "bar", "baz")).getPath();
+		final String typicalComponents = N5URI.getAsUri(kva.compose(uriWithEmptyRoot, "bar", "baz")).getPath();
 		assertEquals("Empty Path, no empty or slash in components", "/bar/baz", typicalComponents);
 
-		final String firstComponentLeadingSlash = URI.create(kva.compose(uriWithEmptyRoot, "/bar", "baz")).getPath();
+		final String firstComponentLeadingSlash = N5URI.getAsUri(kva.compose(uriWithEmptyRoot, "/bar", "baz")).getPath();
 		assertEquals("Empty Path, first components leading slash", "/bar/baz", firstComponentLeadingSlash);
 
-		final String firstComponentSlashOnly = URI.create(kva.compose(uriWithEmptyRoot, "/", "bar", "baz")).getPath();
+		final String firstComponentSlashOnly = N5URI.getAsUri(kva.compose(uriWithEmptyRoot, "/", "bar", "baz")).getPath();
 		assertEquals("Empty Path, first components slash only", "/bar/baz", firstComponentSlashOnly);
 
-		final String firstComponentEmpty = URI.create(kva.compose(uriWithEmptyRoot, "", "bar", "baz")).getPath();
+		final String firstComponentEmpty = N5URI.getAsUri(kva.compose(uriWithEmptyRoot, "", "bar", "baz")).getPath();
 		assertEquals("Empty Path, first components slash only", "/bar/baz", firstComponentEmpty);
 
-		final String firstComponentEmptySecondLeadingSlash = URI.create(kva.compose(uriWithEmptyRoot, "", "/bar", "baz")).getPath();
+		final String firstComponentEmptySecondLeadingSlash = N5URI.getAsUri(kva.compose(uriWithEmptyRoot, "", "/bar", "baz")).getPath();
 		assertEquals("Empty Path, first components slash only", "/bar/baz", firstComponentEmptySecondLeadingSlash);
 
-		final String innerNullEmptyComponents = URI.create(kva.compose(uriWithEmptyRoot, "bar", null, "", "baz")).getPath();
+		final String innerNullEmptyComponents = N5URI.getAsUri(kva.compose(uriWithEmptyRoot, "bar", null, "", "baz")).getPath();
 		assertEquals("Non-empty Path, null and empty inner components", "/bar/baz", innerNullEmptyComponents);
 
-		final String innerNullEmptyComponentsLeadingSlash = URI.create(kva.compose(uriWithEmptyRoot, "/bar", null, "", "baz")).getPath();
+		final String innerNullEmptyComponentsLeadingSlash = N5URI.getAsUri(kva.compose(uriWithEmptyRoot, "/bar", null, "", "baz")).getPath();
 		assertEquals("Non-empty Path, null and empty inner components", "/bar/baz", innerNullEmptyComponentsLeadingSlash);
 	}
 
@@ -235,7 +234,7 @@ public abstract class AbstractKeyValueAccessTest {
 
 		final URI tempUri = uri.resolve("/");
 		final String newUri = tempUri.toString().replaceAll(tempUri.getPath() + "$", path);
-		final URI uriWithNewPath = URI.create(newUri);
+		final URI uriWithNewPath = N5URI.getAsUri(newUri);
 		assertEquals("setUriPath failed", path, uriWithNewPath.getPath());
 		return uriWithNewPath;
 	}

--- a/src/test/java/org/janelia/saalfeldlab/n5/kva/AbstractKeyValueAccessTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/kva/AbstractKeyValueAccessTest.java
@@ -113,9 +113,9 @@ public abstract class AbstractKeyValueAccessTest {
 			/* Don't add the "/" if the input uri path is empty. just use it. Otherwise, remove the parts and start with "/" */
 			final URI baseUri = uri.getPath().isEmpty() ? uri : testUris[i].resolve("/");
 			final String[] components = testPathComponents[i];
-			final String stringUriFromComponents = access.compose(baseUri, components);
-			final URI uriFromComponents = N5URI.getAsUri(stringUriFromComponents);
-			assertEquals("Failure at Index " + i, testUris[i], uriFromComponents);
+			final String actualCompose = access.compose(baseUri, components);
+			final String expectedCompose = access.compose(testUris[i]);
+			assertEquals("Failure at Index " + i, expectedCompose, actualCompose);
 		}
 	}
 
@@ -148,26 +148,13 @@ public abstract class AbstractKeyValueAccessTest {
 		final KeyValueAccess kva = newKeyValueAccess();
 		final URI uriWithPath = setUriPath(uri, "/foo");
 		assertEquals("Non-empty Path", "/foo", uriWithPath.getPath());
-		final String typicalComponents = N5URI.getAsUri(kva.compose(uriWithPath, "bar", "baz")).getPath();
-		assertEquals("Non-empty Path, no empty or slash in components", "/foo/bar/baz", typicalComponents);
-
-		final String firstComponentLeadingSlash = N5URI.getAsUri(kva.compose(uriWithPath, "/bar", "baz")).getPath();
-		assertEquals("Non-empty Path, first components leading slash", "/bar/baz", firstComponentLeadingSlash);
-
-		final String firstComponentSlashOnly = N5URI.getAsUri(kva.compose(uriWithPath, "/", "bar", "baz")).getPath();
-		assertEquals("Non-empty Path, first components slash only", "/bar/baz", firstComponentSlashOnly);
-
-		final String firstComponentEmpty = N5URI.getAsUri(kva.compose(uriWithPath, "", "bar", "baz")).getPath();
-		assertEquals("Non-empty Path, first components slash only", "/foo/bar/baz", firstComponentEmpty);
-
-		final String firstComponentEmptySecondLeadingSlash = N5URI.getAsUri(kva.compose(uriWithPath, "", "/bar", "baz")).getPath();
-		assertEquals("Non-empty Path, first components slash only", "/bar/baz", firstComponentEmptySecondLeadingSlash);
-
-		final String innerNullEmptyComponents = N5URI.getAsUri(kva.compose(uriWithPath, "bar", null, "", "baz")).getPath();
-		assertEquals("Non-empty Path, null and empty inner components", "/foo/bar/baz", innerNullEmptyComponents);
-
-		final String innerNullEmptyComponentsLeadingSlash = N5URI.getAsUri(kva.compose(uriWithPath, "/bar", null, "", "baz")).getPath();
-		assertEquals("Non-empty Path, null and empty inner components", "/bar/baz", innerNullEmptyComponentsLeadingSlash);
+		assertComposeEquals("Non-empty Path, no empty or slash in components", kva, uriWithPath, "/foo/bar/baz", "bar", "baz");
+        assertComposeEquals("Non-empty Path, first components leading slash", kva, uriWithPath, "/bar/baz", "/bar", "baz");
+        assertComposeEquals("Non-empty Path, first components slash only", kva, uriWithPath,"/bar/baz", "/", "bar", "baz");
+        assertComposeEquals("Non-empty Path, first components slash only", kva, uriWithPath,"/foo/bar/baz", "", "bar", "baz");
+        assertComposeEquals("Non-empty Path, first components slash only", kva, uriWithPath,"/bar/baz", "", "/bar", "baz");
+        assertComposeEquals("Non-empty Path, null and empty inner components", kva, uriWithPath,"/foo/bar/baz", "bar", null, "", "baz");
+        assertComposeEquals("Non-empty Path, null and empty inner components", kva, uriWithPath,"/bar/baz", "/bar", null, "", "baz");
 	}
 
 	@Test
@@ -178,26 +165,13 @@ public abstract class AbstractKeyValueAccessTest {
 		testComposeAtLocation(uriWithSlashRoot);
 
 		final KeyValueAccess kva = newKeyValueAccess();
-		final String typicalComponents = N5URI.getAsUri(kva.compose(uriWithSlashRoot, "bar", "baz")).getPath();
-		assertEquals("Root (/) Path, no empty or slash in components", "/bar/baz", typicalComponents);
-
-		final String firstComponentLeadingSlash = N5URI.getAsUri(kva.compose(uriWithSlashRoot, "/bar", "baz")).getPath();
-		assertEquals("Root (/) Path, first components leading slash", "/bar/baz", firstComponentLeadingSlash);
-
-		final String firstComponentSlashOnly = N5URI.getAsUri(kva.compose(uriWithSlashRoot, "/", "bar", "baz")).getPath();
-		assertEquals("Root (/) Path, first components slash only", "/bar/baz", firstComponentSlashOnly);
-
-		final String firstComponentEmpty = N5URI.getAsUri(kva.compose(uriWithSlashRoot, "", "bar", "baz")).getPath();
-		assertEquals("Root (/) Path, first components slash only", "/bar/baz", firstComponentEmpty);
-
-		final String firstComponentEmptySecondLeadingSlash = N5URI.getAsUri(kva.compose(uriWithSlashRoot, "", "/bar", "baz")).getPath();
-		assertEquals("Root (/) Path, first components slash only", "/bar/baz", firstComponentEmptySecondLeadingSlash);
-
-		final String innerNullEmptyComponents = N5URI.getAsUri(kva.compose(uriWithSlashRoot, "bar", null, "", "baz")).getPath();
-		assertEquals("Non-empty Path, null and empty inner components", "/bar/baz", innerNullEmptyComponents);
-
-		final String innerNullEmptyComponentsLeadingSlash = N5URI.getAsUri(kva.compose(uriWithSlashRoot, "/bar", null, "", "baz")).getPath();
-		assertEquals("Non-empty Path, null and empty inner components", "/bar/baz", innerNullEmptyComponentsLeadingSlash);
+		assertComposeEquals("Root (/) Path, no empty or slash in components", kva, uriWithSlashRoot, "/bar/baz", "bar", "baz");
+		assertComposeEquals("Root (/) Path, first components leading slash", kva, uriWithSlashRoot, "/bar/baz", "/bar", "baz");
+		assertComposeEquals("Root (/) Path, first components slash only", kva, uriWithSlashRoot,"/bar/baz", "/", "bar", "baz");
+		assertComposeEquals("Root (/) Path, first components slash only", kva, uriWithSlashRoot,"/bar/baz", "", "bar", "baz");
+		assertComposeEquals("Root (/) Path, first components slash only", kva, uriWithSlashRoot,"/bar/baz", "", "/bar", "baz");
+		assertComposeEquals("Root (/) Path, null and empty inner components", kva, uriWithSlashRoot,"/bar/baz", "bar", null, "", "baz");
+		assertComposeEquals("Root (/) Path, null and empty inner components", kva, uriWithSlashRoot,"/bar/baz", "/bar", null, "", "baz");
 	}
 
 	@Test
@@ -208,26 +182,19 @@ public abstract class AbstractKeyValueAccessTest {
 		testComposeAtLocation(uriWithEmptyRoot);
 
 		final KeyValueAccess kva = newKeyValueAccess();
-		final String typicalComponents = N5URI.getAsUri(kva.compose(uriWithEmptyRoot, "bar", "baz")).getPath();
-		assertEquals("Empty Path, no empty or slash in components", "/bar/baz", typicalComponents);
+		assertComposeEquals("Root (/) Path, no empty or slash in components", kva, uriWithEmptyRoot, "/bar/baz", "bar", "baz");
+		assertComposeEquals("Root (/) Path, first components leading slash", kva, uriWithEmptyRoot, "/bar/baz", "/bar", "baz");
+		assertComposeEquals("Root (/) Path, first components slash only", kva, uriWithEmptyRoot,"/bar/baz", "/", "bar", "baz");
+		assertComposeEquals("Root (/) Path, first components slash only", kva, uriWithEmptyRoot,"/bar/baz", "", "bar", "baz");
+		assertComposeEquals("Root (/) Path, first components slash only", kva, uriWithEmptyRoot,"/bar/baz", "", "/bar", "baz");
+		assertComposeEquals("Root (/) Path, null and empty inner components", kva, uriWithEmptyRoot,"/bar/baz", "bar", null, "", "baz");
+		assertComposeEquals("Root (/) Path, null and empty inner components", kva, uriWithEmptyRoot,"/bar/baz", "/bar", null, "", "baz");
+	}
 
-		final String firstComponentLeadingSlash = N5URI.getAsUri(kva.compose(uriWithEmptyRoot, "/bar", "baz")).getPath();
-		assertEquals("Empty Path, first components leading slash", "/bar/baz", firstComponentLeadingSlash);
-
-		final String firstComponentSlashOnly = N5URI.getAsUri(kva.compose(uriWithEmptyRoot, "/", "bar", "baz")).getPath();
-		assertEquals("Empty Path, first components slash only", "/bar/baz", firstComponentSlashOnly);
-
-		final String firstComponentEmpty = N5URI.getAsUri(kva.compose(uriWithEmptyRoot, "", "bar", "baz")).getPath();
-		assertEquals("Empty Path, first components slash only", "/bar/baz", firstComponentEmpty);
-
-		final String firstComponentEmptySecondLeadingSlash = N5URI.getAsUri(kva.compose(uriWithEmptyRoot, "", "/bar", "baz")).getPath();
-		assertEquals("Empty Path, first components slash only", "/bar/baz", firstComponentEmptySecondLeadingSlash);
-
-		final String innerNullEmptyComponents = N5URI.getAsUri(kva.compose(uriWithEmptyRoot, "bar", null, "", "baz")).getPath();
-		assertEquals("Non-empty Path, null and empty inner components", "/bar/baz", innerNullEmptyComponents);
-
-		final String innerNullEmptyComponentsLeadingSlash = N5URI.getAsUri(kva.compose(uriWithEmptyRoot, "/bar", null, "", "baz")).getPath();
-		assertEquals("Non-empty Path, null and empty inner components", "/bar/baz", innerNullEmptyComponentsLeadingSlash);
+	public void assertComposeEquals(String reason, KeyValueAccess kva, URI uri, String absoluteExpectedPath, String... components) {
+		String actual = kva.compose(uri, components);
+		String expected = kva.compose(uri.resolve(absoluteExpectedPath));
+		assertEquals(reason, expected, actual);
 	}
 
 	public URI setUriPath(final URI uri, final String path) {

--- a/src/test/java/org/janelia/saalfeldlab/n5/kva/FileSystemKeyValueAccessTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/kva/FileSystemKeyValueAccessTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -17,6 +18,8 @@ import java.nio.file.Paths;
 import org.janelia.saalfeldlab.n5.FileSystemKeyValueAccess;
 import org.janelia.saalfeldlab.n5.KeyValueAccess;
 import org.janelia.saalfeldlab.n5.N5URI;
+import org.junit.Ignore;
+import org.junit.Test;
 
 /**
  * @author Stephan Saalfeld &lt;saalfelds@janelia.hhmi.org&gt;
@@ -161,5 +164,23 @@ public class FileSystemKeyValueAccessTest extends AbstractKeyValueAccessTest {
 			final String testPath = FileSystems.getDefault().provider().getPath(absoluteUri).toAbsolutePath().toString();
 			assertEquals("Failure at Index " + i , testPath, composedKey);
 		}
+	}
+
+	@Override
+	@Test
+	@Ignore("Empty path is invalid for file URIs.")
+	public void testComponentsWithPathEmpty() {
+		/* file URIs are purely paths (optional file: scheme) so empty path resolves to a relative path (not the root of the container).
+		 * Because of that, there is no valid file URI with an empty path (it's just an empty string, which is invalid, or `file://` which is invalid. */
+		super.testComponentsWithPathEmpty();
+	}
+
+	@Override
+	@Test
+	@Ignore("Empty path is invalid for file URIs.")
+	public void testComposeWithPathEmpty() {
+		/* file URIs are purely paths (optional file: scheme) so empty path resolves to a relative path (not the root of the container).
+		 * Because of that, there is no valid file URI with an empty path (it's just an empty string, which is invalid, or `file://` which is invalid. */
+		super.testComposeWithPathEmpty();
 	}
 }


### PR DESCRIPTION
Resolves an issue with URI.resolve behavior differences on Java 8 compared to newer versions (tested on Java 21).

On Java 21, the following (correct) behavior is observed when calling `resolve`:

```java
URI.create("http://localhost:8000/").resolve("bar") // -> "http://localhost:8000/bar"
URI.create("http://localhost:8000").resolve("/bar") // -> "http://localhost:8000/bar"
URI.create("http://localhost:8000").resolve("bar")  // -> "http://localhost:8000/bar"
```

For Java 8, all of those are correct, except for the last one, which results in the following:
```java
URI.create("http://localhost:8000").resolve("bar")  // -> "http://localhost:8000bar"
```

Importantly, it incorrectly concatenates "bar" directly to the schemeSpecificPart of the URI, instead of adding it as a pathPart.

This PR ensure the behavior of the default `KeyValueAccess#compose` method handles this correctly on both Java8 and newer Java versions
