### PR TITLE
Migrate IOExceptions to N5IOExceptions for ReadData and related logic

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/Bzip2Compression.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/Bzip2Compression.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -58,6 +58,7 @@ import java.io.InputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
 import org.janelia.saalfeldlab.n5.Compression.CompressionType;
+import org.janelia.saalfeldlab.n5.N5Exception.N5IOException;
 import org.janelia.saalfeldlab.n5.readdata.ReadData;
 
 @CompressionType("bzip2")
@@ -88,9 +89,12 @@ public class Bzip2Compression implements Compression {
 	}
 
 	@Override
-	public ReadData decode(final ReadData readData) throws IOException {
-
-		return ReadData.from(new BZip2CompressorInputStream(readData.inputStream()));
+	public ReadData decode(final ReadData readData) throws N5IOException {
+		try {
+			return ReadData.from(new BZip2CompressorInputStream(readData.inputStream()));
+		} catch (IOException e) {
+			throw new N5IOException(e);
+		}
 	}
 
 	@Override

--- a/src/main/java/org/janelia/saalfeldlab/n5/CachedGsonKeyValueN5Writer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/CachedGsonKeyValueN5Writer.java
@@ -74,11 +74,7 @@ public interface CachedGsonKeyValueN5Writer extends CachedGsonKeyValueN5Reader, 
 		 * the lines below duplicate the single line above but would have to call
 		 * normalizeGroupPath again the below duplicates code, but avoids extra work
 		 */
-		try {
-			getKeyValueAccess().createDirectories(absoluteGroupPath(normalPath));
-		} catch (final IOException | UncheckedIOException e) {
-			throw new N5Exception.N5IOException("Failed to create group " + path, e);
-		}
+		getKeyValueAccess().createDirectories(absoluteGroupPath(normalPath));
 
 		if (cacheMeta()) {
 			// check all nodes that are parents of the added node, if they have
@@ -148,12 +144,9 @@ public interface CachedGsonKeyValueN5Writer extends CachedGsonKeyValueN5Reader, 
 		 */
 		final String normalPath = N5URI.normalizeGroupPath(path);
 		final String groupPath = absoluteGroupPath(normalPath);
-		try {
-			if (getKeyValueAccess().isDirectory(groupPath))
-				getKeyValueAccess().delete(groupPath);
-		} catch (final IOException | UncheckedIOException e) {
-			throw new N5IOException("Failed to remove " + path, e);
-		}
+
+		if (getKeyValueAccess().isDirectory(groupPath))
+			getKeyValueAccess().delete(groupPath);
 
 		if (cacheMeta()) {
 			final String parentPath = getKeyValueAccess().parent(normalPath);

--- a/src/main/java/org/janelia/saalfeldlab/n5/Compression.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/Compression.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -60,6 +60,8 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import org.janelia.saalfeldlab.n5.N5Exception.N5IOException;
 import org.janelia.saalfeldlab.n5.readdata.ReadData;
 import org.scijava.annotations.Indexable;
 
@@ -116,10 +118,10 @@ public interface Compression extends Serializable {
 	 *
 	 * @return decoded ReadData
 	 *
-	 * @throws IOException
+	 * @throws N5IOException
 	 * 		if any I/O error occurs
 	 */
-	ReadData decode(ReadData readData) throws IOException;
+	ReadData decode(ReadData readData) throws N5IOException;
 
 	/**
 	 * Encode the given {@code readData}.
@@ -132,9 +134,9 @@ public interface Compression extends Serializable {
 	 *
 	 * @return encoded ReadData
 	 *
-	 * @throws IOException
+	 * @throws N5IOException
 	 * 		if any I/O error occurs
 	 */
-	ReadData encode(ReadData readData) throws IOException;
+	ReadData encode(ReadData readData) throws N5IOException;
 
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/DefaultBlockReader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/DefaultBlockReader.java
@@ -55,6 +55,8 @@ package org.janelia.saalfeldlab.n5;
 
 import java.io.IOException;
 import java.io.InputStream;
+
+import org.janelia.saalfeldlab.n5.N5Exception.N5IOException;
 import org.janelia.saalfeldlab.n5.codec.DataBlockCodec;
 import org.janelia.saalfeldlab.n5.readdata.ReadData;
 
@@ -76,13 +78,13 @@ public interface DefaultBlockReader {
 	 * @param gridPosition
 	 *            the grid position
 	 * @return the block
-	 * @throws IOException
+	 * @throws N5IOException
 	 *             the exception
 	 */
 	static DataBlock<?> readBlock(
 			final InputStream in,
 			final DatasetAttributes datasetAttributes,
-			final long[] gridPosition) throws IOException {
+			final long[] gridPosition) throws N5IOException {
 
 		final DataBlockCodec<?> codec = datasetAttributes.getDataBlockCodec();
 		return codec.decode(ReadData.from(in), gridPosition);

--- a/src/main/java/org/janelia/saalfeldlab/n5/DefaultBlockWriter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/DefaultBlockWriter.java
@@ -55,6 +55,8 @@ package org.janelia.saalfeldlab.n5;
 
 import java.io.IOException;
 import java.io.OutputStream;
+
+import org.janelia.saalfeldlab.n5.N5Exception.N5IOException;
 import org.janelia.saalfeldlab.n5.codec.DataBlockCodec;
 
 /**
@@ -75,13 +77,13 @@ public interface DefaultBlockWriter {
 	 *            the dataset attributes
 	 * @param dataBlock
 	 *            the data block the block data type
-	 * @throws IOException
+	 * @throws N5IOException
 	 *             the exception
 	 */
 	static <T> void writeBlock(
 			final OutputStream out,
 			final DatasetAttributes datasetAttributes,
-			final DataBlock<T> dataBlock) throws IOException {
+			final DataBlock<T> dataBlock) throws N5IOException {
 
 		final DataBlockCodec<T> codec = datasetAttributes.getDataBlockCodec();
 		codec.encode(dataBlock).writeTo(out);

--- a/src/main/java/org/janelia/saalfeldlab/n5/FileSystemKeyValueAccess.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/FileSystemKeyValueAccess.java
@@ -53,6 +53,8 @@
  */
 package org.janelia.saalfeldlab.n5;
 
+import org.janelia.saalfeldlab.n5.N5Exception.N5NoSuchKeyException;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -191,8 +193,8 @@ public class FileSystemKeyValueAccess implements KeyValueAccess {
 
 		try {
 			return new LockedFileChannel(normalPath, true);
-		} catch (NoSuchFileException e) {
-			throw new N5Exception.N5NoSuchKeyException("No such file", e);
+		} catch (final NoSuchFileException e) {
+			throw new N5NoSuchKeyException("No such file", e);
 		}
 	}
 
@@ -206,8 +208,8 @@ public class FileSystemKeyValueAccess implements KeyValueAccess {
 
 		try {
 			return new LockedFileChannel(path, true);
-		} catch (NoSuchFileException e) {
-			throw new N5Exception.N5NoSuchKeyException("No such file", e);
+		} catch (final NoSuchFileException e) {
+			throw new N5NoSuchKeyException("No such file", e);
 		}
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/FileSystemKeyValueAccess.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/FileSystemKeyValueAccess.java
@@ -53,6 +53,7 @@
  */
 package org.janelia.saalfeldlab.n5;
 
+import org.janelia.saalfeldlab.n5.N5Exception.N5IOException;
 import org.janelia.saalfeldlab.n5.N5Exception.N5NoSuchKeyException;
 
 import java.io.File;
@@ -60,6 +61,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -143,29 +145,40 @@ public class FileSystemKeyValueAccess implements KeyValueAccess {
 			}
 		}
 
+		private void truncateChannel(int size) {
+
+			try {
+				channel.truncate(size);
+			} catch (NoSuchFileException e) {
+				throw new N5NoSuchKeyException("No such file", e);
+			} catch (IOException | UncheckedIOException e ) {
+				throw new N5IOException("Failed to truncate locked file channel", e);
+			}
+		}
+
 		@Override
-		public Reader newReader() throws IOException {
+		public Reader newReader() throws N5IOException {
 
 			return Channels.newReader(channel, StandardCharsets.UTF_8.name());
 		}
 
 		@Override
-		public Writer newWriter() throws IOException {
+		public Writer newWriter() throws N5IOException {
 
-			channel.truncate(0);
+			truncateChannel(0);
 			return Channels.newWriter(channel, StandardCharsets.UTF_8.name());
 		}
 
 		@Override
-		public InputStream newInputStream() throws IOException {
+		public InputStream newInputStream() throws N5IOException {
 
 			return Channels.newInputStream(channel);
 		}
 
 		@Override
-		public OutputStream newOutputStream() throws IOException {
+		public OutputStream newOutputStream() throws N5IOException {
 
-			channel.truncate(0);
+			truncateChannel(0);
 			return Channels.newOutputStream(channel);
 		}
 
@@ -189,33 +202,49 @@ public class FileSystemKeyValueAccess implements KeyValueAccess {
 	}
 
 	@Override
-	public LockedFileChannel lockForReading(final String normalPath) throws IOException {
+	public LockedChannel lockForReading(final String normalPath) throws N5IOException {
 
 		try {
 			return new LockedFileChannel(normalPath, true);
 		} catch (final NoSuchFileException e) {
 			throw new N5NoSuchKeyException("No such file", e);
+		} catch (IOException | UncheckedIOException e) {
+			throw new N5IOException("Failed to lock file for reading: " + normalPath, e);
 		}
 	}
 
 	@Override
-	public LockedFileChannel lockForWriting(final String normalPath) throws IOException {
+	public LockedChannel lockForWriting(final String normalPath) throws N5IOException {
 
-		return new LockedFileChannel(normalPath, false);
+		try {
+			return new LockedFileChannel(normalPath, false);
+		} catch (final NoSuchFileException e) {
+			throw new N5NoSuchKeyException("No such file", e);
+		} catch (IOException | UncheckedIOException e) {
+			throw new N5IOException("Failed to lock file for writing: " + normalPath, e);
+		}
 	}
 
-	public LockedFileChannel lockForReading(final Path path) throws IOException {
+	public LockedChannel lockForReading(final Path path) throws N5IOException {
 
 		try {
 			return new LockedFileChannel(path, true);
 		} catch (final NoSuchFileException e) {
 			throw new N5NoSuchKeyException("No such file", e);
+		} catch (IOException | UncheckedIOException e) {
+			throw new N5IOException("Failed to lock file for reading: " + path, e);
 		}
 	}
 
-	public LockedFileChannel lockForWriting(final Path path) throws IOException {
+	public LockedChannel lockForWriting(final Path path) throws N5IOException {
 
-		return new LockedFileChannel(path, false);
+		try {
+			return new LockedFileChannel(path, false);
+		} catch (final NoSuchFileException e) {
+			throw new N5NoSuchKeyException("No such file", e);
+		} catch (IOException | UncheckedIOException e) {
+			throw new N5IOException("Failed to lock file for writing: " + path, e);
+		}
 	}
 
 	@Override
@@ -240,7 +269,7 @@ public class FileSystemKeyValueAccess implements KeyValueAccess {
 	}
 
 	@Override
-	public String[] listDirectories(final String normalPath) throws IOException {
+	public String[] listDirectories(final String normalPath) throws N5IOException {
 
 		final Path path = fileSystem.getPath(normalPath);
 		try (final Stream<Path> pathStream = Files.list(path)) {
@@ -248,17 +277,25 @@ public class FileSystemKeyValueAccess implements KeyValueAccess {
 					.filter(a -> Files.isDirectory(a))
 					.map(a -> path.relativize(a).toString())
 					.toArray(n -> new String[n]);
+		} catch (NoSuchFileException e) {
+			throw new N5NoSuchKeyException("No such file", e);
+		} catch (IOException | UncheckedIOException e) {
+			throw new N5IOException("Failed to list directories", e);
 		}
 	}
 
 	@Override
-	public String[] list(final String normalPath) throws IOException {
+	public String[] list(final String normalPath) throws N5IOException {
 
 		final Path path = fileSystem.getPath(normalPath);
 		try (final Stream<Path> pathStream = Files.list(path)) {
 			return pathStream
 					.map(a -> path.relativize(a).toString())
 					.toArray(n -> new String[n]);
+		} catch (NoSuchFileException e) {
+			throw new N5NoSuchKeyException("No such file", e);
+		} catch (IOException | UncheckedIOException e) {
+			throw new N5IOException("Failed to list files", e);
 		}
 	}
 
@@ -364,32 +401,42 @@ public class FileSystemKeyValueAccess implements KeyValueAccess {
 	}
 
 	@Override
-	public void createDirectories(final String normalPath) throws IOException {
+	public void createDirectories(final String normalPath) throws N5IOException {
 
-		createDirectories(fileSystem.getPath(normalPath));
+		try {
+			createDirectories(fileSystem.getPath(normalPath));
+		} catch (NoSuchFileException e) {
+			throw new N5NoSuchKeyException("No such file", e);
+		} catch (IOException | UncheckedIOException e) {
+			throw new N5IOException("Failed to create directories", e);
+		}
 	}
 
 	@Override
-	public void delete(final String normalPath) throws IOException {
+	public void delete(final String normalPath) throws N5IOException {
 
-		final Path path = fileSystem.getPath(normalPath);
+		try {
+			final Path path = fileSystem.getPath(normalPath);
 
-		if (Files.isRegularFile(path))
-			try (final LockedChannel channel = lockForWriting(path)) {
-				Files.delete(path);
-			}
-		else {
-			try (final Stream<Path> pathStream = Files.walk(path)) {
-				for (final Iterator<Path> i = pathStream.sorted(Comparator.reverseOrder()).iterator(); i.hasNext();) {
-					final Path childPath = i.next();
-					if (Files.isRegularFile(childPath))
-						try (final LockedChannel channel = lockForWriting(childPath)) {
-							Files.delete(childPath);
-						}
-					else
-						tryDelete(childPath);
+			if (Files.isRegularFile(path))
+				try (final LockedChannel channel = lockForWriting(path)) {
+					Files.delete(path);
+				}
+			else {
+				try (final Stream<Path> pathStream = Files.walk(path)) {
+					for (final Iterator<Path> i = pathStream.sorted(Comparator.reverseOrder()).iterator(); i.hasNext();) {
+						final Path childPath = i.next();
+						if (Files.isRegularFile(childPath))
+							try (final LockedChannel channel = lockForWriting(childPath)) {
+								Files.delete(childPath);
+							}
+						else
+							tryDelete(childPath);
+					}
 				}
 			}
+		} catch (IOException | UncheckedIOException e) {
+			throw new N5IOException("Failed to delete file at " + normalPath, e);
 		}
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/GsonKeyValueN5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/GsonKeyValueN5Reader.java
@@ -83,7 +83,7 @@ public interface GsonKeyValueN5Reader extends GsonN5Reader {
 			return GsonUtils.readAttributes(lockedChannel.newReader(), getGson());
 		} catch (final N5Exception.N5NoSuchKeyException e) {
 			return null;
-		} catch (final IOException | UncheckedIOException e) {
+		} catch (final IOException | UncheckedIOException | N5IOException e) {
 			throw new N5IOException("Failed to read attributes from dataset " + pathName, e);
 		}
 
@@ -101,7 +101,7 @@ public interface GsonKeyValueN5Reader extends GsonN5Reader {
 			return DefaultBlockReader.readBlock(lockedChannel.newInputStream(), datasetAttributes, gridPosition);
 		} catch (final N5Exception.N5NoSuchKeyException e) {
 			return null;
-		} catch (final IOException | UncheckedIOException e) {
+		} catch (final IOException | UncheckedIOException | N5IOException e) {
 			throw new N5IOException(
 					"Failed to read block " + Arrays.toString(gridPosition) + " from dataset " + path,
 					e);
@@ -111,11 +111,7 @@ public interface GsonKeyValueN5Reader extends GsonN5Reader {
 	@Override
 	default String[] list(final String pathName) throws N5Exception {
 
-		try {
-			return getKeyValueAccess().listDirectories(absoluteGroupPath(pathName));
-		} catch (final IOException | UncheckedIOException e) {
-			throw new N5IOException("Cannot list directories for group " + pathName, e);
-		}
+		return getKeyValueAccess().listDirectories(absoluteGroupPath(pathName));
 	}
 
 	/**

--- a/src/main/java/org/janelia/saalfeldlab/n5/GsonUtils.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/GsonUtils.java
@@ -70,6 +70,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
+import org.janelia.saalfeldlab.n5.N5Exception.N5JsonParseException;
 
 /**
  * Utility class for working with  JSON.
@@ -94,13 +95,10 @@ public interface GsonUtils {
 	 * @param gson
 	 * 			  to parse Json from the {@code reader}
 	 * @return the root {@link JsonObject} of the attributes
-	 * @throws IOException
-	 *             if an error occurs reading json from the {@code reader}
 	 */
-	static JsonElement readAttributes(final Reader reader, final Gson gson) throws IOException {
+	static JsonElement readAttributes(final Reader reader, final Gson gson) {
 
-		final JsonElement json = gson.fromJson(reader, JsonElement.class);
-		return json;
+		return gson.fromJson(reader, JsonElement.class);
 	}
 
 	static <T> T readAttribute(
@@ -237,13 +235,13 @@ public interface GsonUtils {
 	 *            the json element
 	 * @return the attribute map
 	 */
-	static Map<String, Class<?>> listAttributes(final JsonElement root) throws N5Exception.N5IOException {
+	static Map<String, Class<?>> listAttributes(final JsonElement root) throws N5JsonParseException {
 
 		if (root == null) {
 			return new HashMap<>();
 		}
 		if (!root.isJsonObject()) {
-			throw new N5Exception("JsonElement found, but was not JsonObject");
+			throw new N5JsonParseException("JsonElement found, but was not JsonObject");
 		}
 
 		final HashMap<String, Class<?>> attributes = new HashMap<>();

--- a/src/main/java/org/janelia/saalfeldlab/n5/GzipCompression.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/GzipCompression.java
@@ -62,6 +62,7 @@ import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipParameters;
 import org.janelia.saalfeldlab.n5.Compression.CompressionType;
+import org.janelia.saalfeldlab.n5.N5Exception.N5IOException;
 import org.janelia.saalfeldlab.n5.readdata.ReadData;
 
 @CompressionType("gzip")
@@ -113,13 +114,17 @@ public class GzipCompression implements Compression {
 	}
 
 	@Override
-	public ReadData decode(final ReadData readData) throws IOException {
+	public ReadData decode(final ReadData readData) throws N5IOException {
 
-		return ReadData.from(decode(readData.inputStream()));
+		try {
+			return ReadData.from(decode(readData.inputStream()));
+		} catch (IOException e) {
+			throw new N5IOException(e);
+		}
 	}
 
 	@Override
-	public ReadData encode(final ReadData readData) {
+	public ReadData encode(final ReadData readData)  {
 		if (useZlib) {
 			return readData.encode(out -> new DeflaterOutputStream(out, new Deflater(level)));
 		} else {

--- a/src/main/java/org/janelia/saalfeldlab/n5/HttpKeyValueAccess.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/HttpKeyValueAccess.java
@@ -216,7 +216,7 @@ public class HttpKeyValueAccess implements KeyValueAccess {
 	}
 
 	@Override
-	public LockedChannel lockForReading(final String normalPath) throws IOException {
+	public LockedChannel lockForReading(final String normalPath) throws N5IOException {
 		//TODO Caleb: Maybe check exists lazily when attempting to read
 		try {
 			if (!exists(normalPath))
@@ -228,7 +228,7 @@ public class HttpKeyValueAccess implements KeyValueAccess {
 	}
 
 	@Override
-	public LockedChannel lockForWriting(final String normalPath) throws IOException {
+	public LockedChannel lockForWriting(final String normalPath) throws N5IOException {
 
 		throw new N5Exception("HttpKeyValueAccess is read-only");
 	}
@@ -242,11 +242,11 @@ public class HttpKeyValueAccess implements KeyValueAccess {
 	 *            is expected to be in normalized form, no further
 	 *            efforts are made to normalize it.
 	 * @return the directories
-	 * @throws IOException
+	 * @throws N5IOException
 	 *             if an error occurs during listing
 	 */
 	@Override
-	public String[] listDirectories(final String normalPath) throws IOException {
+	public String[] listDirectories(final String normalPath) throws N5IOException {
 
 		return queryListEntries(normalPath, listDirectoryResponseParser, true);
 	}
@@ -261,16 +261,16 @@ public class HttpKeyValueAccess implements KeyValueAccess {
 	 *            is expected to be in normalized form, no further efforts are
 	 *            made to normalize it.
 	 * @return the the child paths
-	 * @throws IOException
+	 * @throws N5IOException
 	 *             if an error occurs during listing
 	 */
 	@Override
-	public String[] list(final String normalPath) throws IOException {
+	public String[] list(final String normalPath) throws N5IOException {
 
 		return queryListEntries(normalPath, listResponseParser, true);
 	}
 
-	private String[] queryListEntries(String normalPath, ListResponseParser parser, boolean allowRedirect) {
+	private String[] queryListEntries(String normalPath, ListResponseParser parser, boolean allowRedirect) throws N5IOException{
 
 		final HttpURLConnection http = requireValidHttpResponse(normalPath, "GET", "Error listing directory at " + normalPath, allowRedirect);
 		try {
@@ -341,13 +341,17 @@ public class HttpKeyValueAccess implements KeyValueAccess {
 		}
 
 		@Override
-		public InputStream newInputStream() throws IOException {
+		public InputStream newInputStream() throws N5IOException {
 
-			return uri.toURL().openStream();
+			try {
+				return uri.toURL().openStream();
+			} catch (IOException e) {
+				throw new N5IOException("Could not open stream for " + uri, e);
+			}
 		}
 
 		@Override
-		public Reader newReader() throws IOException {
+		public Reader newReader() throws N5IOException {
 
 			final InputStreamReader reader = new InputStreamReader(newInputStream(), StandardCharsets.UTF_8);
 			synchronized (resources) {
@@ -357,13 +361,13 @@ public class HttpKeyValueAccess implements KeyValueAccess {
 		}
 
 		@Override
-		public OutputStream newOutputStream() {
+		public OutputStream newOutputStream() throws N5IOException {
 
 			throw new NonWritableChannelException();
 		}
 
 		@Override
-		public Writer newWriter() {
+		public Writer newWriter() throws N5IOException {
 
 			throw new NonWritableChannelException();
 		}

--- a/src/main/java/org/janelia/saalfeldlab/n5/HttpKeyValueAccess.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/HttpKeyValueAccess.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -26,30 +26,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-/**
- * Copyright (c) 2017, Stephan Saalfeld All rights reserved.
- * <p>
- * Redistribution and use in source and binary forms, with or without modification, are permitted
- * provided that the following conditions are met:
- * <p>
- * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
- * and the following disclaimer. 2. Redistributions in binary form must reproduce the above
- * copyright notice, this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- * <p>
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
- * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
- * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package org.janelia.saalfeldlab.n5;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.function.TriFunction;
+import org.janelia.saalfeldlab.n5.N5Exception.N5IOException;
 import org.janelia.saalfeldlab.n5.http.ListResponseParser;
 
 import java.io.Closeable;
@@ -85,7 +66,7 @@ public class HttpKeyValueAccess implements KeyValueAccess {
 	/**
 	 * Opens an {@link HttpKeyValueAccess}
 	 *
-	 * @throws N5Exception.N5IOException if the access could not be created
+	 * @throws N5IOException if the access could not be created
 	 */
 	public HttpKeyValueAccess() {
 
@@ -296,7 +277,7 @@ public class HttpKeyValueAccess implements KeyValueAccess {
 			final String listResponse = responseToString(http.getInputStream());
 			return parser.parseListResponse(listResponse);
 		} catch (IOException e) {
-			throw new N5Exception.N5IOException("Error listing directory at " + normalPath, e);
+			throw new N5IOException("Error listing directory at " + normalPath, e);
 		}
 	}
 
@@ -324,7 +305,7 @@ public class HttpKeyValueAccess implements KeyValueAccess {
 			code = http.getResponseCode();
 			responseMsg = http.getResponseMessage();
 		} catch (IOException e) {
-			throw new N5Exception.N5IOException("Could not validate HTTP Response", e);
+			throw new N5IOException("Could not validate HTTP Response", e);
 		}
 
 		final N5Exception cause = filterCode.apply(code, responseMsg, http);

--- a/src/main/java/org/janelia/saalfeldlab/n5/KeyValueAccess.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/KeyValueAccess.java
@@ -53,7 +53,8 @@
  */
 package org.janelia.saalfeldlab.n5;
 
-import java.io.IOException;
+import org.janelia.saalfeldlab.n5.N5Exception.N5IOException;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.FileSystem;
@@ -263,10 +264,10 @@ public interface KeyValueAccess {
 	 *            is expected to be in normalized form, no further
 	 *            efforts are made to normalize it.
 	 * @return the locked channel
-	 * @throws IOException
+	 * @throws N5IOException
 	 *             if a locked channel could not be created
 	 */
-	public LockedChannel lockForReading(final String normalPath) throws IOException;
+	public LockedChannel lockForReading(final String normalPath) throws N5IOException;
 
 	/**
 	 * Create an exclusive lock on a path for writing. If the file doesn't
@@ -283,10 +284,10 @@ public interface KeyValueAccess {
 	 *            is expected to be in normalized form, no further
 	 *            efforts are made to normalize it.
 	 * @return the locked channel
-	 * @throws IOException
+	 * @throws N5IOException
 	 *             if a locked channel could not be created
 	 */
-	public LockedChannel lockForWriting(final String normalPath) throws IOException;
+	public LockedChannel lockForWriting(final String normalPath) throws N5IOException;
 
 	/**
 	 * List all 'directory'-like children of a path.
@@ -295,10 +296,10 @@ public interface KeyValueAccess {
 	 *            is expected to be in normalized form, no further
 	 *            efforts are made to normalize it.
 	 * @return the directories
-	 * @throws IOException
+	 * @throws N5IOException
 	 *             if an error occurs during listing
 	 */
-	public String[] listDirectories(final String normalPath) throws IOException;
+	public String[] listDirectories(final String normalPath) throws N5IOException;
 
 	/**
 	 * List all children of a path.
@@ -307,9 +308,9 @@ public interface KeyValueAccess {
 	 *            is expected to be in normalized form, no further
 	 *            efforts are made to normalize it.
 	 * @return the the child paths
-	 * @throws IOException if an error occurs during listing
+	 * @throws N5IOException if an error occurs during listing
 	 */
-	public String[] list(final String normalPath) throws IOException;
+	public String[] list(final String normalPath) throws N5IOException;
 
 	/**
 	 * Create a directory and all parent paths along the way. The directory
@@ -320,10 +321,10 @@ public interface KeyValueAccess {
 	 * @param normalPath
 	 *            is expected to be in normalized form, no further
 	 *            efforts are made to normalize it.
-	 * @throws IOException
+	 * @throws N5IOException
 	 *             if an error occurs during creation
 	 */
-	public void createDirectories(final String normalPath) throws IOException;
+	public void createDirectories(final String normalPath) throws N5IOException;
 
 	/**
 	 * Delete a path. If the path is a directory, delete it recursively.
@@ -331,8 +332,8 @@ public interface KeyValueAccess {
 	 * @param normalPath
 	 *            is expected to be in normalized form, no further
 	 *            efforts are made to normalize it.
-	 * @throws IOException
+	 * @throws N5IOException
 	 *            if an error occurs during deletion
 	 */
-	public void delete(final String normalPath) throws IOException;
+	public void delete(final String normalPath) throws N5IOException;
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/LockedChannel.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/LockedChannel.java
@@ -53,6 +53,8 @@
  */
 package org.janelia.saalfeldlab.n5;
 
+import org.janelia.saalfeldlab.n5.N5Exception.N5IOException;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -72,35 +74,35 @@ public interface LockedChannel extends Closeable {
 	 * Create a UTF-8 {@link Reader}.
 	 *
 	 * @return the reader
-	 * @throws IOException
+	 * @throws N5IOException
 	 *             if the reader could not be created
 	 */
-	public Reader newReader() throws IOException;
+	public Reader newReader() throws N5IOException;
 
 	/**
 	 * Create a new {@link InputStream}.
 	 *
 	 * @return the input stream
-	 * @throws IOException
+	 * @throws N5IOException
 	 *             if an input stream could not be created
 	 */
-	public InputStream newInputStream() throws IOException;
+	public InputStream newInputStream() throws N5IOException;
 
 	/**
 	 * Create a new UTF-8 {@link Writer}.
 	 *
 	 * @return the writer
-	 * @throws IOException
+	 * @throws N5IOException
 	 *             if a writer could not be created
 	 */
-	public Writer newWriter() throws IOException;
+	public Writer newWriter() throws N5IOException;
 
 	/**
 	 * Create a new {@link OutputStream}.
 	 *
 	 * @return the output stream
-	 * @throws IOException
+	 * @throws N5IOException
 	 *             if an output stream could not be created
 	 */
-	public OutputStream newOutputStream() throws IOException;
+	public OutputStream newOutputStream() throws N5IOException;
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/Lz4Compression.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/Lz4Compression.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -53,10 +53,10 @@
  */
 package org.janelia.saalfeldlab.n5;
 
-import java.io.IOException;
 import net.jpountz.lz4.LZ4BlockInputStream;
 import net.jpountz.lz4.LZ4BlockOutputStream;
 import org.janelia.saalfeldlab.n5.Compression.CompressionType;
+import org.janelia.saalfeldlab.n5.N5Exception.N5IOException;
 import org.janelia.saalfeldlab.n5.readdata.ReadData;
 
 @CompressionType("lz4")
@@ -87,7 +87,7 @@ public class Lz4Compression implements Compression {
 	}
 
 	@Override
-	public ReadData decode(final ReadData readData) throws IOException {
+	public ReadData decode(final ReadData readData) throws N5IOException {
 
 		return ReadData.from(new LZ4BlockInputStream(readData.inputStream()));
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Exception.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Exception.java
@@ -149,4 +149,33 @@ public class N5Exception extends RuntimeException {
 			super(message, cause, enableSuppression, writableStackTrace);
 		}
 	}
+
+	/**
+	 * Exception to represent an error when attempting to parse json attributes
+	 */
+	public static class N5JsonParseException extends N5Exception {
+		public N5JsonParseException(final String message) {
+
+			super(message);
+		}
+
+		public N5JsonParseException(final String message, final Throwable cause) {
+
+			super(message, cause);
+		}
+
+		public N5JsonParseException(final Throwable cause) {
+
+			super(cause);
+		}
+
+		protected N5JsonParseException(
+				final String message,
+				final Throwable cause,
+				final boolean enableSuppression,
+				final boolean writableStackTrace) {
+
+			super(message, cause, enableSuppression, writableStackTrace);
+		}
+	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/XzCompression.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/XzCompression.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -54,10 +54,10 @@
 package org.janelia.saalfeldlab.n5;
 
 import java.io.IOException;
-import java.io.InputStream;
 import org.apache.commons.compress.compressors.xz.XZCompressorInputStream;
 import org.apache.commons.compress.compressors.xz.XZCompressorOutputStream;
 import org.janelia.saalfeldlab.n5.Compression.CompressionType;
+import org.janelia.saalfeldlab.n5.N5Exception.N5IOException;
 import org.janelia.saalfeldlab.n5.readdata.ReadData;
 
 @CompressionType("xz")
@@ -88,9 +88,13 @@ public class XzCompression implements Compression {
 	}
 
 	@Override
-	public ReadData decode(final ReadData readData) throws IOException {
+	public ReadData decode(final ReadData readData) throws N5IOException {
 
-		return ReadData.from(new XZCompressorInputStream(readData.inputStream()));
+		try {
+			return ReadData.from(new XZCompressorInputStream(readData.inputStream()));
+		} catch (IOException e) {
+			throw new N5IOException(e);
+		}
 	}
 
 	@Override

--- a/src/main/java/org/janelia/saalfeldlab/n5/codec/DataBlockCodec.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/codec/DataBlockCodec.java
@@ -28,8 +28,9 @@
  */
 package org.janelia.saalfeldlab.n5.codec;
 
-import java.io.IOException;
 import org.janelia.saalfeldlab.n5.DataBlock;
+import org.janelia.saalfeldlab.n5.N5Exception;
+import org.janelia.saalfeldlab.n5.N5Exception.N5IOException;
 import org.janelia.saalfeldlab.n5.readdata.ReadData;
 
 /**
@@ -40,7 +41,7 @@ import org.janelia.saalfeldlab.n5.readdata.ReadData;
  */
 public interface DataBlockCodec<T> {
 
-	ReadData encode(DataBlock<T> dataBlock) throws IOException;
+	ReadData encode(DataBlock<T> dataBlock) throws N5IOException;
 
-	DataBlock<T> decode(ReadData readData, long[] gridPosition) throws IOException;
+	DataBlock<T> decode(ReadData readData, long[] gridPosition) throws N5IOException;
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/codec/N5Codecs.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/codec/N5Codecs.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -43,10 +43,12 @@ import org.janelia.saalfeldlab.n5.DoubleArrayDataBlock;
 import org.janelia.saalfeldlab.n5.FloatArrayDataBlock;
 import org.janelia.saalfeldlab.n5.IntArrayDataBlock;
 import org.janelia.saalfeldlab.n5.LongArrayDataBlock;
+import org.janelia.saalfeldlab.n5.N5Exception;
 import org.janelia.saalfeldlab.n5.ShortArrayDataBlock;
 import org.janelia.saalfeldlab.n5.StringDataBlock;
 import org.janelia.saalfeldlab.n5.readdata.ReadData;
 
+import static org.janelia.saalfeldlab.n5.N5Exception.*;
 import static org.janelia.saalfeldlab.n5.codec.N5Codecs.BlockHeader.MODE_DEFAULT;
 import static org.janelia.saalfeldlab.n5.codec.N5Codecs.BlockHeader.MODE_OBJECT;
 import static org.janelia.saalfeldlab.n5.codec.N5Codecs.BlockHeader.MODE_VARLENGTH;
@@ -134,11 +136,10 @@ public class N5Codecs {
 			this.compression = compression;
 		}
 
-		abstract BlockHeader createBlockHeader(final DataBlock<T> dataBlock, ReadData blockData) throws IOException;
+		abstract BlockHeader createBlockHeader(final DataBlock<T> dataBlock, ReadData blockData) throws N5IOException;
 
 		@Override
-		public ReadData encode(DataBlock<T> dataBlock) throws IOException {
-
+		public ReadData encode(DataBlock<T> dataBlock) throws N5IOException {
 			return ReadData.from(out -> {
 				final ReadData dataReadData = dataCodec.serialize(dataBlock.getData());
 				final ReadData encodedData = compression.encode(dataReadData);
@@ -149,10 +150,10 @@ public class N5Codecs {
 			});
 		}
 
-		abstract BlockHeader decodeBlockHeader(final InputStream in) throws IOException;
+		abstract BlockHeader decodeBlockHeader(final InputStream in) throws N5IOException;
 
 		@Override
-		public DataBlock<T> decode(final ReadData readData, final long[] gridPosition) throws IOException {
+		public DataBlock<T> decode(final ReadData readData, final long[] gridPosition) throws N5IOException {
 
 			try(final InputStream in = readData.inputStream()) {
 				final BlockHeader header = decodeBlockHeader(in);
@@ -166,6 +167,8 @@ public class N5Codecs {
 				final ReadData decodeData = compression.decode(ReadData.from(in));
 				final T data = dataCodec.deserialize(decodeData, numElements);
 				return dataBlockFactory.createDataBlock(header.blockSize(), gridPosition, data);
+			} catch (IOException e) {
+				throw new N5IOException(e);
 			}
 		}
 	}
@@ -190,7 +193,7 @@ public class N5Codecs {
 		}
 
 		@Override
-		protected BlockHeader decodeBlockHeader(final InputStream in) throws IOException {
+		protected BlockHeader decodeBlockHeader(final InputStream in) throws N5IOException {
 
 			return BlockHeader.readFrom(in, MODE_DEFAULT, MODE_VARLENGTH);
 		}
@@ -207,13 +210,13 @@ public class N5Codecs {
 		}
 
 		@Override
-		protected BlockHeader createBlockHeader(final DataBlock<String[]> dataBlock, ReadData blockData) throws IOException {
+		protected BlockHeader createBlockHeader(final DataBlock<String[]> dataBlock, ReadData blockData) throws N5IOException {
 
 			return new BlockHeader(dataBlock.getSize(), (int)blockData.length());
 		}
 
 		@Override
-		protected BlockHeader decodeBlockHeader(final InputStream in) throws IOException {
+		protected BlockHeader decodeBlockHeader(final InputStream in) throws N5IOException {
 
 			return BlockHeader.readFrom(in, MODE_DEFAULT, MODE_VARLENGTH);
 		}
@@ -236,7 +239,7 @@ public class N5Codecs {
 		}
 
 		@Override
-		protected BlockHeader decodeBlockHeader(final InputStream in) throws IOException {
+		protected BlockHeader decodeBlockHeader(final InputStream in) throws N5IOException {
 
 			return BlockHeader.readFrom(in, MODE_OBJECT);
 		}
@@ -282,78 +285,95 @@ public class N5Codecs {
 			return numElements;
 		}
 
-		private static int[] readBlockSize(final DataInputStream dis) throws IOException {
+		private static int[] readBlockSize(final DataInputStream dis) throws N5IOException {
 
-			final int nDim = dis.readShort();
-			final int[] blockSize = new int[nDim];
-			for (int d = 0; d < nDim; ++d)
-				blockSize[d] = dis.readInt();
-			return blockSize;
-		}
-
-		private static void writeBlockSize(final int[] blockSize, final DataOutputStream dos) throws IOException {
-
-			dos.writeShort(blockSize.length);
-			for (final int size : blockSize)
-				dos.writeInt(size);
-		}
-
-		void writeTo(final OutputStream out) throws IOException {
-
-			final DataOutputStream dos = new DataOutputStream(out);
-			dos.writeShort(mode);
-			switch (mode) {
-			case MODE_DEFAULT:// default
-				writeBlockSize(blockSize, dos);
-				break;
-			case MODE_VARLENGTH:// varlength
-				writeBlockSize(blockSize, dos);
-				dos.writeInt(numElements);
-				break;
-			case MODE_OBJECT: // object
-				dos.writeInt(numElements);
-				break;
-			default:
-				throw new IOException("unexpected mode: " + mode);
+			try {
+				final int nDim = dis.readShort();
+				final int[] blockSize = new int[nDim];
+				for (int d = 0; d < nDim; ++d)
+					blockSize[d] = dis.readInt();
+				return blockSize;
+			} catch (IOException e) {
+				throw new N5IOException(e);
 			}
-			dos.flush();
 		}
 
-		static BlockHeader readFrom(final InputStream in, short... allowedModes) throws IOException {
+		private static void writeBlockSize(final int[] blockSize, final DataOutputStream dos) throws N5IOException {
 
-			final DataInputStream dis = new DataInputStream(in);
-			final short mode = dis.readShort();
-			final int[] blockSize;
-			final int numElements;
-			switch (mode) {
-			case MODE_DEFAULT:// default
-				blockSize = readBlockSize(dis);
-				numElements = DataBlock.getNumElements(blockSize);
-				break;
-			case MODE_VARLENGTH:// varlength
-				blockSize = readBlockSize(dis);
-				numElements = dis.readInt();
-				break;
-			case MODE_OBJECT: // object
-				blockSize = null;
-				numElements = dis.readInt();
-				break;
-			default:
-				throw new IOException("Unexpected mode: " + mode);
+			try {
+				dos.writeShort(blockSize.length);
+				for (final int size : blockSize)
+					dos.writeInt(size);
+			} catch (IOException e) {
+				throw new N5IOException(e);
 			}
+		}
 
-			boolean modeIsOk = allowedModes == null || allowedModes.length == 0;
-			for (int i = 0; !modeIsOk && i < allowedModes.length; ++i) {
-				if (mode == allowedModes[i]) {
-					modeIsOk = true;
+		void writeTo(final OutputStream out) throws N5IOException {
+
+			try {
+				final DataOutputStream dos = new DataOutputStream(out);
+				dos.writeShort(mode);
+				switch (mode) {
+				case MODE_DEFAULT:// default
+					writeBlockSize(blockSize, dos);
 					break;
+				case MODE_VARLENGTH:// varlength
+					writeBlockSize(blockSize, dos);
+					dos.writeInt(numElements);
+					break;
+				case MODE_OBJECT: // object
+					dos.writeInt(numElements);
+					break;
+				default:
+					throw new N5Exception("unexpected mode: " + mode);
 				}
-			}
-			if (!modeIsOk) {
-				throw new IOException("Unexpected mode: " + mode);
+				dos.flush();
+			} catch (IOException e) {
+				throw new N5IOException(e);
 			}
 
-			return new BlockHeader(mode, blockSize, numElements);
+		}
+
+		static BlockHeader readFrom(final InputStream in, short... allowedModes) throws N5IOException, N5Exception {
+
+			try {
+				final DataInputStream dis = new DataInputStream(in);
+				final short mode = dis.readShort();
+				final int[] blockSize;
+				final int numElements;
+				switch (mode) {
+				case MODE_DEFAULT:// default
+					blockSize = readBlockSize(dis);
+					numElements = DataBlock.getNumElements(blockSize);
+					break;
+				case MODE_VARLENGTH:// varlength
+					blockSize = readBlockSize(dis);
+					numElements = dis.readInt();
+					break;
+				case MODE_OBJECT: // object
+					blockSize = null;
+					numElements = dis.readInt();
+					break;
+				default:
+					throw new N5Exception("Unexpected mode: " + mode);
+				}
+
+				boolean modeIsOk = allowedModes == null || allowedModes.length == 0;
+				for (int i = 0; !modeIsOk && i < allowedModes.length; ++i) {
+					if (mode == allowedModes[i]) {
+						modeIsOk = true;
+						break;
+					}
+				}
+				if (!modeIsOk) {
+					throw new N5Exception("Unexpected mode: " + mode);
+				}
+
+				return new BlockHeader(mode, blockSize, numElements);
+			} catch (IOException e) {
+				throw new N5IOException(e);
+			}
 		}
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/readdata/ByteArraySplittableReadData.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/readdata/ByteArraySplittableReadData.java
@@ -29,7 +29,6 @@
 package org.janelia.saalfeldlab.n5.readdata;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 
@@ -55,7 +54,7 @@ class ByteArraySplittableReadData implements ReadData {
 	}
 
 	@Override
-	public InputStream inputStream() throws IOException {
+	public InputStream inputStream() {
 		return new ByteArrayInputStream(data, offset, length);
 	}
 
@@ -69,7 +68,7 @@ class ByteArraySplittableReadData implements ReadData {
 	}
 
 	@Override
-	public ReadData materialize() throws IOException {
+	public ReadData materialize() {
 		return this;
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/readdata/KeyValueAccessReadData.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/readdata/KeyValueAccessReadData.java
@@ -33,7 +33,6 @@ import java.io.InputStream;
 import org.apache.commons.io.input.ProxyInputStream;
 import org.janelia.saalfeldlab.n5.KeyValueAccess;
 import org.janelia.saalfeldlab.n5.LockedChannel;
-import org.janelia.saalfeldlab.n5.N5Exception;
 import org.janelia.saalfeldlab.n5.N5Exception.N5IOException;
 
 class KeyValueAccessReadData extends AbstractInputStreamReadData {
@@ -60,19 +59,16 @@ class KeyValueAccessReadData extends AbstractInputStreamReadData {
 	 */
 	@Override
 	public InputStream inputStream() throws N5IOException {
-		try {
-			@SuppressWarnings("resource")
-			final LockedChannel channel = keyValueAccess.lockForReading(normalPath);
-			return new ProxyInputStream(channel.newInputStream()) {
 
-				@Override
-				public void close() throws IOException {
-					in.close();
-					channel.close();
-				}
-			};
-		} catch (final IOException e) {
-			throw new N5IOException(e);
-		}
+		@SuppressWarnings("resource")
+		final LockedChannel channel = keyValueAccess.lockForReading(normalPath);
+		return new ProxyInputStream(channel.newInputStream()) {
+
+			@Override
+			public void close() throws IOException {
+				in.close();
+				channel.close();
+			}
+		};
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/readdata/KeyValueAccessReadData.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/readdata/KeyValueAccessReadData.java
@@ -33,6 +33,8 @@ import java.io.InputStream;
 import org.apache.commons.io.input.ProxyInputStream;
 import org.janelia.saalfeldlab.n5.KeyValueAccess;
 import org.janelia.saalfeldlab.n5.LockedChannel;
+import org.janelia.saalfeldlab.n5.N5Exception;
+import org.janelia.saalfeldlab.n5.N5Exception.N5IOException;
 
 class KeyValueAccessReadData extends AbstractInputStreamReadData {
 
@@ -53,19 +55,24 @@ class KeyValueAccessReadData extends AbstractInputStreamReadData {
 	 *
 	 * @return an InputStream on this data
 	 *
-	 * @throws IOException
+	 * @throws N5IOException
 	 * 		if any I/O error occurs
 	 */
 	@Override
-	public InputStream inputStream() throws IOException {
-		final LockedChannel channel = keyValueAccess.lockForReading(normalPath);
-		return new ProxyInputStream(channel.newInputStream()) {
+	public InputStream inputStream() throws N5IOException {
+		try {
+			@SuppressWarnings("resource")
+			final LockedChannel channel = keyValueAccess.lockForReading(normalPath);
+			return new ProxyInputStream(channel.newInputStream()) {
 
-			@Override
-			public void close() throws IOException {
-				in.close();
-				channel.close();
-			}
-		};
+				@Override
+				public void close() throws IOException {
+					in.close();
+					channel.close();
+				}
+			};
+		} catch (final IOException e) {
+			throw new N5IOException(e);
+		}
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/readdata/LazyReadData.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/readdata/LazyReadData.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -33,6 +33,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import org.apache.commons.io.output.ProxyOutputStream;
+import org.janelia.saalfeldlab.n5.N5Exception;
+import org.janelia.saalfeldlab.n5.N5Exception.N5IOException;
 
 class LazyReadData implements ReadData {
 
@@ -62,7 +64,7 @@ class LazyReadData implements ReadData {
 	private ByteArraySplittableReadData bytes;
 
 	@Override
-	public ReadData materialize() throws IOException {
+	public ReadData materialize() throws N5IOException {
 		if (bytes == null) {
 			final ByteArrayOutputStream baos = new ByteArrayOutputStream(8192);
 			writeTo(baos);
@@ -72,26 +74,31 @@ class LazyReadData implements ReadData {
 	}
 
 	@Override
-	public long length() throws IOException {
+	public long length() throws N5IOException {
+
 		return materialize().length();
 	}
 
 	@Override
-	public InputStream inputStream() throws IOException, IllegalStateException {
+	public InputStream inputStream() throws N5IOException, IllegalStateException {
 		return materialize().inputStream();
 	}
 
 	@Override
-	public byte[] allBytes() throws IOException, IllegalStateException {
+	public byte[] allBytes() throws N5IOException, IllegalStateException {
 		return materialize().allBytes();
 	}
 
 	@Override
-	public void writeTo(final OutputStream outputStream) throws IOException, IllegalStateException {
-		if (bytes != null) {
-			outputStream.write(bytes.allBytes());
-		} else {
-			writer.writeTo(outputStream);
+	public void writeTo(final OutputStream outputStream) throws N5IOException, IllegalStateException {
+		try {
+			if (bytes != null) {
+				outputStream.write(bytes.allBytes());
+			} else {
+				writer.writeTo(outputStream);
+			}
+		} catch (IOException e) {
+			throw new N5IOException(e);
 		}
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/readdata/ReadData.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/readdata/ReadData.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -33,6 +33,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import org.janelia.saalfeldlab.n5.KeyValueAccess;
+import org.janelia.saalfeldlab.n5.N5Exception.N5IOException;
 
 /**
  * An abstraction over {@code byte[]} data.
@@ -59,10 +60,10 @@ public interface ReadData {
 	 *
 	 * @return number of bytes, if known, or -1
 	 *
-	 * @throws IOException
+	 * @throws N5IOException
 	 * 		if an I/O error occurs while trying to get the length
 	 */
-	default long length() throws IOException {
+	default long length() throws N5IOException {
 		return -1;
 	}
 
@@ -77,12 +78,12 @@ public interface ReadData {
 	 *
 	 * @return an InputStream on this data
 	 *
-	 * @throws IOException
+	 * @throws N5IOException
 	 * 		if any I/O error occurs
 	 * @throws IllegalStateException
 	 * 		if this method was already called once and cannot be called again.
 	 */
-	InputStream inputStream() throws IOException, IllegalStateException;
+	InputStream inputStream() throws N5IOException, IllegalStateException;
 
 	/**
 	 * Return the contained data as a {@code byte[]} array.
@@ -96,12 +97,12 @@ public interface ReadData {
 	 *
 	 * @return all contained data as a byte[] array
 	 *
-	 * @throws IOException
+	 * @throws N5IOException
 	 * 		if any I/O error occurs
 	 * @throws IllegalStateException
 	 * 		if {@link #inputStream()} was already called once and cannot be called again.
 	 */
-	byte[] allBytes() throws IOException, IllegalStateException;
+	byte[] allBytes() throws N5IOException, IllegalStateException;
 
 	/**
 	 * Return the contained data as a {@code ByteBuffer}.
@@ -116,12 +117,12 @@ public interface ReadData {
 	 *
 	 * @return all contained data as a ByteBuffer
 	 *
-	 * @throws IOException
+	 * @throws N5IOException
 	 * 		if any I/O error occurs
 	 * @throws IllegalStateException
 	 * 		if {@link #inputStream()} was already called once and cannot be called again.
 	 */
-	default ByteBuffer toByteBuffer() throws IOException, IllegalStateException {
+	default ByteBuffer toByteBuffer() throws N5IOException, IllegalStateException {
 		return ByteBuffer.wrap(allBytes());
 	}
 
@@ -133,7 +134,7 @@ public interface ReadData {
 	 * The returned {@code ReadData} has a known {@link #length} and multiple
 	 * {@link #inputStream InputStreams} can be opened on it.
 	 */
-	ReadData materialize() throws IOException;
+	ReadData materialize() throws N5IOException;
 
 	/**
 	 * Write the contained data into an {@code OutputStream}.
@@ -148,13 +149,17 @@ public interface ReadData {
 	 * @param outputStream
 	 * 		destination to write to
 	 *
-	 * @throws IOException
+	 * @throws N5IOException
 	 * 		if any I/O error occurs
 	 * @throws IllegalStateException
 	 * 		if {@link #inputStream()} was already called once and cannot be called again.
 	 */
-	default void writeTo(OutputStream outputStream) throws IOException, IllegalStateException {
-		outputStream.write(allBytes());
+	default void writeTo(OutputStream outputStream) throws N5IOException, IllegalStateException {
+		try {
+			outputStream.write(allBytes());
+		} catch (IOException e) {
+			throw new N5IOException(e);
+		}
 	}
 
 	// ------------- Encoding / Decoding ----------------

--- a/src/test/java/org/janelia/saalfeldlab/n5/N5Benchmark.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/N5Benchmark.java
@@ -67,6 +67,7 @@ import java.util.concurrent.Future;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import ch.systemsx.cisd.base.mdarray.MDShortArray;
@@ -250,6 +251,7 @@ public class N5Benchmark {
 	}
 
 	@Test
+	@Ignore
 	public void benchmarkParallelWritingSpeed() {
 
 		final int nBlocks = 5;

--- a/src/test/java/org/janelia/saalfeldlab/n5/N5FSTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/N5FSTest.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -26,31 +26,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-/**
- * Copyright (c) 2017--2021, Stephan Saalfeld
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
 package org.janelia.saalfeldlab.n5;
 
 import static org.junit.Assert.fail;
@@ -63,7 +38,6 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -107,7 +81,7 @@ public class N5FSTest extends AbstractN5Test {
 
 	@Override protected N5Writer createN5Writer() throws IOException, URISyntaxException {
 
-		return new N5FSWriter(tempN5Location(), new GsonBuilder());
+		return createN5Writer(tempN5Location(), new GsonBuilder());
 	}
 
 	@Override
@@ -193,7 +167,6 @@ public class N5FSTest extends AbstractN5Test {
 	@Test
 	public void testLockReleaseByReader() throws IOException, ExecutionException, InterruptedException, TimeoutException {
 
-		System.out.println("Testing lock release by Reader.");
 
 		final Path path = Paths.get(tempN5PathName(), "lock");
 		final LockedChannel lock = access.lockForWriting(path);


### PR DESCRIPTION
when working with data backed by ReadData, it's not possible to know where the underlying data is coming from. We expect to deal with N5IOExceptions rather than IOException, especially when the ReadData is wrapping a KeyValueAccess read/write. This has the added benefit of letting the ReadData provider wrap the specific IOException with an appropriate N5 specific N5IOException, such as N5NoSuchKeyException.