### PR TITLE
Use python3 rather than python on macOS

### DIFF
--- a/src/test/java/org/janelia/saalfeldlab/n5/http/RunnerWithHttpServer.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/http/RunnerWithHttpServer.java
@@ -133,7 +133,9 @@ public class RunnerWithHttpServer extends BlockJUnit4ClassRunner {
 	public void startHttpServer() throws Exception {
 
 		httpServerDirectory = createTmpServerDirectory();
-		ProcessBuilder processBuilder = new ProcessBuilder("python", "-m", "http.server");
+		final String osName = System.getProperty("os.name");
+		final String pythonBinary = "Mac OS X".equals(osName) ? "python3" : "python";
+		ProcessBuilder processBuilder = new ProcessBuilder(pythonBinary, "-m", "http.server");
 		processBuilder.directory(httpServerDirectory.toFile());
 		processBuilder.redirectErrorStream(true);
 		process = processBuilder.start();


### PR DESCRIPTION
With 72e9a7674b96ce916a48de00fa9e479e36888c84, a dependency on `python` is introduced. But on newer macOS versions, the system binary is `/usr/bin/python3`; there is no `python` binary nor symlink. So related tests here error out:
```
[ERROR] org.janelia.saalfeldlab.n5.http.N5HttpTest.null
[ERROR]   Run 1: N5HttpTest » IO Cannot run program "python" (in directory "/var/folders/58/xzyl05g94wb69j0vtbqdq92h0000gn/T/n5-http-test-server-3861032598968023987"): error=2, No such file or directory
[ERROR]   Run 2: N5HttpTest » NullPointer
[INFO]
[ERROR] org.janelia.saalfeldlab.n5.kva.HttpKeyValueAccessTest.null
[ERROR]   Run 1: HttpKeyValueAccessTest » IO Cannot run program "python" (in directory "/var/folders/58/xzyl05g94wb69j0vtbqdq92h0000gn/T/n5-http-test-server-3736070965945471518"): error=2, No such file or directory
[ERROR]   Run 2: HttpKeyValueAccessTest » NullPointer
```
This commit lets unit tests pass on macOS by hardcoding `python3` instead of `python` for that operating system.
