### PR TITLE
feat: make KeyValueAccessReadData constructor public

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/KeyValueAccessReadData.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/KeyValueAccessReadData.java
@@ -17,7 +17,7 @@ public class KeyValueAccessReadData implements ReadData {
     private final long offset;
     private long length;
 
-    KeyValueAccessReadData(LazyRead lazyRead) {
+    public KeyValueAccessReadData(LazyRead lazyRead) {
         this(lazyRead, 0, -1);
     }
 


### PR DESCRIPTION
* need to create these in other (e.g. S3) KeyValueAccess implementations