### PR TITLE
`createDataset` returns (possibly new) DatasetAttributes

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Writer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Writer.java
@@ -28,8 +28,6 @@
  */
 package org.janelia.saalfeldlab.n5;
 
-import org.janelia.saalfeldlab.n5.codec.BlockCodecInfo;
-import org.janelia.saalfeldlab.n5.codec.DataCodecInfo;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -199,39 +197,46 @@ public interface N5Writer extends N5Reader {
 
 	/**
 	 * Creates a dataset. This does not create any data but the path and
-	 * mandatory attributes only.
+	 * mandatory attributes only. The returned DatasetAttributes should be used
+	 * for future read/write operations on this dataset. It may not be the same
+	 * DatasetAttributes object that was provided, depending on the implementation.
 	 *
 	 * @param datasetPath dataset path
 	 * @param datasetAttributes the dataset attributes
-	 * @throws N5Exception the exception
+	 * @return DatasetAttributes optimal attributes object to be used for read/write operations
+	 * @throws N5Exception
 	 */
-	default void createDataset(
+	default DatasetAttributes createDataset(
 			final String datasetPath,
 			final DatasetAttributes datasetAttributes) throws N5Exception {
 
 		final String normalPath = N5URI.normalizeGroupPath(datasetPath);
 		createGroup(normalPath);
 		setDatasetAttributes(normalPath, datasetAttributes);
+		return datasetAttributes;
 	}
 
 	/**
 	 * Creates a dataset. This does not create any data but the path and
-	 * mandatory attributes only.
+	 * mandatory attributes only. Returns the DatasetAttributes object to be
+	 * used for future read/write operations on this dataset.
 	 *
 	 * @param datasetPath dataset path
 	 * @param dimensions the dataset dimensions
 	 * @param blockSize the block size
 	 * @param dataType the data type
 	 * @param compression the compression
+	 * @return DatasetAttributes optimal attributes object to be used for read/write operations
+	 * @throws N5Exception
 	 */
-	default void createDataset(
+	default DatasetAttributes createDataset(
 			final String datasetPath,
 			final long[] dimensions,
 			final int[] blockSize,
 			final DataType dataType,
 			final Compression compression) throws N5Exception {
 
-		createDataset(datasetPath, new DatasetAttributes(dimensions, blockSize, dataType, compression));
+		return createDataset(datasetPath, new DatasetAttributes(dimensions, blockSize, dataType, compression));
 	}
 
 	/**

--- a/src/test/java/org/janelia/saalfeldlab/n5/http/HttpReaderFsWriter.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/http/HttpReaderFsWriter.java
@@ -33,7 +33,6 @@ import com.google.gson.JsonElement;
 import org.janelia.saalfeldlab.n5.CachedGsonKeyValueN5Reader;
 import org.janelia.saalfeldlab.n5.CachedGsonKeyValueN5Writer;
 import org.janelia.saalfeldlab.n5.DataBlock;
-import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.GsonKeyValueN5Reader;
 import org.janelia.saalfeldlab.n5.GsonKeyValueN5Writer;
@@ -50,8 +49,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Predicate;
-
-import static org.janelia.saalfeldlab.n5.N5KeyValueReader.ATTRIBUTES_JSON;
 
 public class HttpReaderFsWriter implements GsonKeyValueN5Writer {
 
@@ -263,9 +260,10 @@ public class HttpReaderFsWriter implements GsonKeyValueN5Writer {
 		return writer.remove();
 	}
 
-	@Override public void createDataset(String datasetPath, DatasetAttributes datasetAttributes) throws N5Exception {
+	@Override public DatasetAttributes createDataset(String datasetPath, DatasetAttributes datasetAttributes) throws N5Exception {
 
 		writer.createDataset(datasetPath, datasetAttributes);
+		return datasetAttributes;
 	}
 
 	@Override public <T> void writeBlock(String datasetPath, DatasetAttributes datasetAttributes, DataBlock<T> dataBlock) throws N5Exception {


### PR DESCRIPTION
N5Writers that require specific implementation of DatasetAttributes (such as Zarr) must convert the passed in DatasetAttributes to the specific implementation they need. To that end `createDataset` now returns a DatasetAttributes object. If a conversion was done, the converted object should be returned. Otherwise, this input DatasetAttributes can be returned directly. 

The returns DatasetAttributes object can be used for future read/write calls to avoid repeated conversions