### PR TITLE
Add default implementation of N5writer.writeRegion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.janelia.saalfeldlab</groupId>
 	<artifactId>n5</artifactId>
-	<version>4.0.0-alpha-7-SNAPSHOT</version>
+	<version>4.0.0-alpha-8-SNAPSHOT</version>
 
 	<name>N5</name>
 	<description>Not HDF5</description>

--- a/src/main/java/org/janelia/saalfeldlab/n5/GsonKeyValueN5Writer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/GsonKeyValueN5Writer.java
@@ -298,10 +298,9 @@ public interface GsonKeyValueN5Writer extends GsonN5Writer, GsonKeyValueN5Reader
 	@Override
 	default boolean deleteBlock(
 			final String path,
+			final DatasetAttributes datasetAttributes,
 			final long... gridPosition) throws N5Exception {
 
-		final String normalPath = N5URI.normalizeGroupPath(path);
-		final DatasetAttributes datasetAttributes = getDatasetAttributes(normalPath);
 		final PositionValueAccess posKva = PositionValueAccess.fromKva(getKeyValueAccess(), getURI(), N5URI.normalizeGroupPath(path), datasetAttributes);
 		return datasetAttributes.getDatasetAccess().deleteBlock(posKva, gridPosition);
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/GsonKeyValueN5Writer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/GsonKeyValueN5Writer.java
@@ -308,10 +308,9 @@ public interface GsonKeyValueN5Writer extends GsonN5Writer, GsonKeyValueN5Reader
 	@Override
 	default boolean deleteBlocks(
 			final String path,
+			final DatasetAttributes datasetAttributes,
 			final List<long[]> gridPositions) throws N5Exception {
 
-		final String normalPath = N5URI.normalizeGroupPath(path);
-		final DatasetAttributes datasetAttributes = getDatasetAttributes(normalPath);
 		final PositionValueAccess posKva = PositionValueAccess.fromKva(getKeyValueAccess(), getURI(), N5URI.normalizeGroupPath(path), datasetAttributes);
 		return datasetAttributes.getDatasetAccess().deleteBlocks(posKva, gridPositions);
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Writer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Writer.java
@@ -334,9 +334,27 @@ public interface N5Writer extends N5Reader {
 	 *
 	 * @return {@code true} if the block at {@code gridPosition} existed and was deleted.
 	 */
-	boolean deleteBlock(
+	default boolean deleteBlock(
 			final String datasetPath,
-			final long... gridPosition) throws N5Exception;
+			final long... gridPosition) throws N5Exception {
+		final DatasetAttributes datasetAttributes = getDatasetAttributes(datasetPath);
+		return deleteBlock(datasetPath, datasetAttributes, gridPosition);
+	}
+
+	/**
+	 * Deletes the block at {@code gridPosition}.
+	 *
+	 * @param datasetPath the dataset path
+	 * @param datasetAttributes the dataset attributes
+	 * @param gridPosition position of block to be deleted
+	 * @throws N5Exception if the block exists but could not be deleted
+	 *
+	 * @return {@code true} if the block at {@code gridPosition} existed and was deleted.
+	 */
+	boolean deleteBlock(
+			String datasetPath,
+			DatasetAttributes datasetAttributes,
+			long... gridPosition) throws N5Exception;
 
 	/**
 	 * Deletes the blocks at the given {@code gridPositions}.

--- a/src/main/java/org/janelia/saalfeldlab/n5/N5Writer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5Writer.java
@@ -365,11 +365,12 @@ public interface N5Writer extends N5Reader {
 	 * @throws N5Exception if any of the block exists but could not be deleted
 	 */
 	default boolean deleteBlocks(
-			final String datasetPath,
-			final List<long[]> gridPositions) throws N5Exception {
+			String datasetPath,
+			DatasetAttributes datasetAttributes,
+			List<long[]> gridPositions) throws N5Exception {
 		boolean deleted = false;
 		for (long[] pos : gridPositions) {
-			deleted |= deleteBlock(datasetPath, pos);
+			deleted |= deleteBlock(datasetPath, datasetAttributes, pos);
 		}
 		return deleted;
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/shard/Region.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/shard/Region.java
@@ -39,7 +39,7 @@ import org.janelia.saalfeldlab.n5.shard.Nesting.NestedGrid;
  * Provides methods to find which blocks and shards are contained in the
  * region, iterate sub-NestedPositions, etc.
  */
-class Region {
+public class Region {
 
 	/**
 	 * The dimensions of the full dataset.
@@ -72,7 +72,7 @@ class Region {
 	 */
 	private final Nesting.NestedPosition maxPos;
 
-	Region(final long[] min, final long[] size, final NestedGrid grid) {
+	public Region(final long[] min, final long[] size, final NestedGrid grid) {
 		this.min = min;
 		this.size = size;
 		this.grid = grid;
@@ -93,14 +93,14 @@ class Region {
 	/**
 	 * Get the {@code NestedPosition} of the minimum DataBlock touched by the region.
 	 */
-	Nesting.NestedPosition minPos() {
+	public Nesting.NestedPosition minPos() {
 		return minPos;
 	}
 
 	/**
 	 * Get the {@code NestedPosition} of the maximum DataBlock touched by the region.
 	 */
-	Nesting.NestedPosition maxPos() {
+	public Nesting.NestedPosition maxPos() {
 		return maxPos;
 	}
 
@@ -116,7 +116,7 @@ class Region {
 	 *
 	 * @return true, if the given position is fully contained in this region
 	 */
-	boolean fullyContains(final Nesting.NestedPosition position) {
+	public boolean fullyContains(final Nesting.NestedPosition position) {
 
 		final long[] pmin = position.pixelPosition();
 		for (int d = 0; d < pmin.length; d++) {
@@ -165,7 +165,7 @@ class Region {
 	}
 
 	// TODO: Revise to accept Consumer<long[]> for handling each position
-	static List<long[]> gridPositions(final long[] min, final long[] max) {
+	public static List<long[]> gridPositions(final long[] min, final long[] max) {
 		final int n = min.length;
 		final long[] pos = min.clone();
 		int numElements = 1;

--- a/src/test/java/org/janelia/saalfeldlab/n5/http/HttpReaderFsWriter.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/http/HttpReaderFsWriter.java
@@ -281,9 +281,9 @@ public class HttpReaderFsWriter implements GsonKeyValueN5Writer {
 		return writer.deleteBlock(datasetPath, gridPosition);
 	}
 
-	@Override public boolean deleteBlocks(String datasetPath, List<long[]> gridPositions) throws N5Exception {
+	@Override public boolean deleteBlocks(String datasetPath, DatasetAttributes datasetAttributes, List<long[]> gridPositions) throws N5Exception {
 
-		return writer.deleteBlocks(datasetPath, gridPositions);
+		return writer.deleteBlocks(datasetPath, datasetAttributes, gridPositions);
 	}
 
 	@Override public void writeSerializedBlock(Serializable object, String datasetPath, DatasetAttributes datasetAttributes, long... gridPosition) throws N5Exception {


### PR DESCRIPTION
Add a fallback default implementation of `N5Writer.writeRegion.`

Add a variant of `N5Writer.deleteBlock` that takes a `DatasetAttributes` argument, and a default implementation of the existing `deleteBlock` that reads the `DatasetAttributes` and forwards to the new variant.

Let `N5Writer.deleteBlocks` take a `DatasetAttributes` argument.