### PR TITLE
perf: Improved decoding from InputStreams

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/codec/FlatArrayCodec.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/codec/FlatArrayCodec.java
@@ -132,7 +132,7 @@ public abstract class FlatArrayCodec<T> {
 		public byte[] decode(final ReadData readData, int numElements) throws N5IOException {
 			final byte[] data = newArray(numElements);
 			try {
-				new DataInputStream(readData.inputStream()).readFully(data);
+				new DataInputStream(readData.limit(numElements).inputStream()).readFully(data);
 			} catch (IOException e) {
 				throw new N5IOException(e);
 			}
@@ -159,7 +159,7 @@ public abstract class FlatArrayCodec<T> {
 		@Override
 		public short[] decode(final ReadData readData, int numElements) throws N5IOException {
 			final short[] data = newArray(numElements);
-			readData.toByteBuffer().order(order).asShortBuffer().get(data);
+			readData.limit(2 * numElements).toByteBuffer().order(order).asShortBuffer().get(data);
 			return data;
 		}
 	}
@@ -183,7 +183,7 @@ public abstract class FlatArrayCodec<T> {
 		@Override
 		public int[] decode(final ReadData readData, int numElements) throws N5IOException {
 			final int[] data = newArray(numElements);
-			final ByteBuffer byteBuffer = readData.toByteBuffer();
+			final ByteBuffer byteBuffer = readData.limit(4 * numElements).toByteBuffer();
 			final IntBuffer intBuffer = byteBuffer.order(order).asIntBuffer();
 			intBuffer.get(data);
 			return data;
@@ -209,7 +209,7 @@ public abstract class FlatArrayCodec<T> {
 		@Override
 		public long[] decode(final ReadData readData, int numElements) throws N5IOException {
 			final long[] data = newArray(numElements);
-			readData.toByteBuffer().order(order).asLongBuffer().get(data);
+			readData.limit(8 * numElements).toByteBuffer().order(order).asLongBuffer().get(data);
 			return data;
 		}
 	}
@@ -233,7 +233,7 @@ public abstract class FlatArrayCodec<T> {
 		@Override
 		public float[] decode(final ReadData readData, int numElements) throws N5IOException {
 			final float[] data = newArray(numElements);
-			readData.toByteBuffer().order(order).asFloatBuffer().get(data);
+			readData.limit(4 * numElements).toByteBuffer().order(order).asFloatBuffer().get(data);
 			return data;
 		}
 	}
@@ -257,7 +257,7 @@ public abstract class FlatArrayCodec<T> {
 		@Override
 		public double[] decode(final ReadData readData, int numElements) throws N5IOException {
 			final double[] data = newArray(numElements);
-			readData.toByteBuffer().order(order).asDoubleBuffer().get(data);
+			readData.limit(8 * numElements).toByteBuffer().order(order).asDoubleBuffer().get(data);
 			return data;
 		}
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/codec/FlatArrayCodec.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/codec/FlatArrayCodec.java
@@ -30,6 +30,7 @@ package org.janelia.saalfeldlab.n5.codec;
 
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
@@ -131,8 +132,8 @@ public abstract class FlatArrayCodec<T> {
 		@Override
 		public byte[] decode(final ReadData readData, int numElements) throws N5IOException {
 			final byte[] data = newArray(numElements);
-			try {
-				new DataInputStream(readData.limit(numElements).inputStream()).readFully(data);
+			try (final InputStream is = readData.limit(numElements).inputStream()) {
+				new DataInputStream(is).readFully(data);
 			} catch (IOException e) {
 				throw new N5IOException(e);
 			}
@@ -347,8 +348,8 @@ public abstract class FlatArrayCodec<T> {
 		@Override
 		public byte[] decode(ReadData readData, int numElements) throws N5IOException {
 			final byte[] data = newArray(numElements);
-			try {
-				new DataInputStream(readData.inputStream()).readFully(data);
+			try (final InputStream is = readData.inputStream()) {
+				new DataInputStream(is).readFully(data);
 			} catch (IOException e) {
 				throw new N5IOException(e);
 			}

--- a/src/main/java/org/janelia/saalfeldlab/n5/codec/N5BlockCodecs.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/codec/N5BlockCodecs.java
@@ -282,16 +282,7 @@ public class N5BlockCodecs {
 
 		public int getSize() {
 
-			switch (mode) {
-				case MODE_DEFAULT:
-					return 2 + 4 * blockSize.length;
-				case MODE_VARLENGTH:
-					return 2 + 4 * blockSize.length + 4;
-				case MODE_OBJECT:
-					return 2 + 4;
-				default:
-					throw new IllegalArgumentException("Unexpected mode: " + mode);
-			}
+			return headerSizeInBytes(mode, blockSize == null ? 0 : blockSize.length);
 		}
 
 		public int[] blockSize() {

--- a/src/main/java/org/janelia/saalfeldlab/n5/codec/N5BlockCodecs.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/codec/N5BlockCodecs.java
@@ -150,18 +150,24 @@ public class N5BlockCodecs {
 		@Override
 		public DataBlock<T> decode(final ReadData readData, final long[] gridPosition) throws N5IOException {
 
+			// read block header with input stream since header is variable length
+			final BlockHeader header;
 			try(final InputStream in = readData.inputStream()) {
-				final BlockHeader header = decodeBlockHeader(in);
-
-				final int numElements = header.numElements();
-				final ReadData decodeData = codec.decode(ReadData.from(in));
-
-				// the dataCodec knows the number of bytes per element
-				final T data = dataCodec.decode(decodeData, numElements);
-				return dataBlockFactory.createDataBlock(header.blockSize(), gridPosition, data);
+				header = decodeBlockHeader(in);
 			} catch (IOException e) {
 				throw new N5IOException(e);
 			}
+
+			// determine length
+			// and slice original read data so that bodyReadData is known length
+			final int numElements = header.numElements();
+			final long bodyLength = readData.length() - header.getSize();
+			final ReadData bodyReadData = bodyLength > 0 ? readData.slice(header.getSize(), bodyLength) : ReadData.empty();
+			final ReadData decodeData = codec.decode(bodyReadData);
+
+			// the dataCodec knows the number of bytes per element
+			final T data = dataCodec.decode(decodeData, numElements);
+			return dataBlockFactory.createDataBlock(header.blockSize(), gridPosition, data);
 		}
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/readdata/InputStreamReadData.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/readdata/InputStreamReadData.java
@@ -66,6 +66,11 @@ class InputStreamReadData implements ReadData {
 		return bytes.slice(offset, length);
 	}
 
+	@Override
+	public ReadData limit(final long length) {
+		return new InputStreamReadData(inputStream, (int)length);
+	}
+
 	private boolean inputStreamCalled = false;
 
 	@Override


### PR DESCRIPTION
This PR improves decoding performance by using the known decoded size of a block in bytes. The primary changes are:

* Calling `limit` on the `ReadData` used in `FlatArrayCodec`
* Overriding `limit` in `InputStreamReadData` so that it can have an expected size without materializing
  * [The default `limit` method calls `slice`](https://github.com/saalfeldlab/n5/blob/1c01e846f8726a6c773af14fb400a4dde36d4c39/src/main/java/org/janelia/saalfeldlab/n5/readdata/ReadData.java#L92-L94). and `InputStreamReadData.slice` calls `materialize`.

We call `org.apache.commons.io.IOUtils.toByteArray(...)` to [materialize](https://github.com/saalfeldlab/n5/blob/1c01e846f8726a6c773af14fb400a4dde36d4c39/src/main/java/org/janelia/saalfeldlab/n5/readdata/InputStreamReadData.java#L104) `InputStreamReadData` 
of unknown size, and have [previously identified](https://github.com/saalfeldlab/n5/issues/161#issuecomment-3053182248) that this call is much slower than the alternative path with known size.

An `InputStreamReadData` can arise during de-coding, for example during [ZStandard decompression.](https://github.com/JaneliaSciComp/n5-zstandard/blob/6da448702e0a32ff546e2afc627a0ec90085d923/src/main/java/org/janelia/scicomp/n5/zstandard/ZstandardCompression.java#L555)


See also https://github.com/saalfeldlab/n5/issues/161
@tpietzsch @cmhulbert 