### PR TITLE
fix: ignore "Bad file descriptor" on close

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/FileSystemKeyValueAccess.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/FileSystemKeyValueAccess.java
@@ -516,7 +516,19 @@ public class FileSystemKeyValueAccess implements KeyValueAccess {
 		public void close() throws IOException {
 
 			if (lock != null) {
-				lock.close();
+				try {
+					lock.close();
+				} catch (IOException e) {
+					/* this is a particular case. Sometimes (seemingly only on MacOs, when accessing blocks
+					* over a SMB mount). Reading succeeds, but closing throws a "Bad File Descriptor" IOException.
+					* Since the read succeeded, we are willing to ignore this exception. */
+					boolean ignoreBadFileDescriptorOnClose = e.getMessage().matches("^Bad file descriptor$");
+
+					if (!ignoreBadFileDescriptorOnClose) {
+						throw e;
+					}
+
+				}
 				lock = null;
 			}
 		}


### PR DESCRIPTION
Sometimes (seemingly only on MacOs, when accessing blocks over a SMB mount),  reading through a FileSystem KVA succeeds, but closing throws a "Bad file descriptor" IOException. 
Since the read succeeded, we are willing to ignore this exception. 

This has not been thoroughly investigated, but a few things seem to be true that indicate it's related to the SMB mount:
- This doesn't happen right away, but when it does happen, it continues to happen frequently, even across processes (i.e. relaunching the same script/test).
- When it does happen, unmounting and remounting can resolve this, even during the runtime of an application (presuming the application doesn't try to read/write while it's unmounted)
